### PR TITLE
Connect dashboard to live APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Productivity Dashboard
+
+## API Configuration
+
+This dashboard relies on several external APIs. Replace the placeholder `YOUR_*` values in `public/main.js` with your own keys.
+
+- **Weather**: [WeatherAPI](https://www.weatherapi.com/)
+  - Endpoint: `https://api.weatherapi.com/v1/forecast.json`
+  - Key: `WEATHERAPI_KEY`
+- **Events**: [Google Calendar API](https://developers.google.com/calendar)
+  - Endpoint: `https://www.googleapis.com/calendar/v3/calendars/primary/events`
+  - Key: `GOOGLE_CALENDAR_API_KEY`
+- **Photos**: [Unsplash API](https://unsplash.com/developers)
+  - Endpoint: `https://api.unsplash.com/photos/random`
+  - Key: `UNSPLASH_ACCESS_KEY`
+
+### CORS
+
+Requests are proxied through `https://cors-anywhere.herokuapp.com/`. You may need to request temporary access from that service for local development or configure your own proxy.


### PR DESCRIPTION
## Summary
- Replace placeholder URLs with WeatherAPI, Google Calendar, and Unsplash endpoints
- Improve `fetchWithMock` to surface HTTP errors
- Reduce mock data use and document API keys & CORS proxy setup

## Testing
- `node --check public/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa03e438e4832f97ac8fef1f9e2985