### PR TITLE
Clear old event animation timers before refreshing events

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,12 +338,20 @@
         };
 
         let activeIntervals = [];
+        let eventAnimationIntervals = [];
         let currentCalendar = [];
 
         // --- Core Functions ---
         function stopAllIntervals() {
             activeIntervals.forEach(clearInterval);
             activeIntervals = [];
+            eventAnimationIntervals = [];
+        }
+
+        function clearEventAnimationIntervals() {
+            eventAnimationIntervals.forEach(clearInterval);
+            activeIntervals = activeIntervals.filter(id => !eventAnimationIntervals.includes(id));
+            eventAnimationIntervals = [];
         }
 
         async function fetchWithMock(url, mockData) {
@@ -515,6 +523,7 @@
             ];
             currentCalendar = await fetchWithMock(config.eventsUrl, mockEvents);
             elements.eventsList.innerHTML = '';
+            clearEventAnimationIntervals();
             
             if (currentCalendar && currentCalendar.length > 0) {
                 const eventGroups = groupEventsByTime(currentCalendar); 
@@ -574,7 +583,9 @@
             };
             
             animationCycle();
-            activeIntervals.push(setInterval(animationCycle, 5000));
+            const intervalId = setInterval(animationCycle, 5000);
+            activeIntervals.push(intervalId);
+            eventAnimationIntervals.push(intervalId);
         }
         
         async function createSlideshow(container, settings, photosUrl, mockData) {


### PR DESCRIPTION
## Summary
- Track event group animation intervals separately from other timers
- Clear previous event animation intervals before re-rendering events
- Avoid accumulating duplicate timers for event bubble animations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ff1ea6e4832f90d79e5fb2d29da6