### PR TITLE
Add Jest test setup for helper utilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/README.md
+++ b/README.md
@@ -17,3 +17,16 @@ This dashboard relies on several external APIs. Replace the placeholder `YOUR_*`
 ### CORS
 
 Requests are proxied through `https://cors-anywhere.herokuapp.com/`. You may need to request temporary access from that service for local development or configure your own proxy.
+
+## Testing
+
+This project uses [Jest](https://jestjs.io/) for unit tests.
+
+```bash
+npm install
+npm test
+```
+
+### Continuous Integration
+
+A GitHub Actions workflow runs `npm test` on each push and pull request to ensure helpers continue to work as expected.

--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -1,0 +1,49 @@
+const { formatTimeRange, formatLocationName, getStatusFromEvent } = require('../public/helpers');
+
+describe('formatTimeRange', () => {
+  test('omits meridian on start when both times share it', () => {
+    expect(formatTimeRange('10:00 AM', '11:30 AM')).toBe('10 - 11:30 am');
+  });
+
+  test('keeps meridian when times differ', () => {
+    expect(formatTimeRange('11:00 AM', '1:00 PM')).toBe('11 am - 1 pm');
+  });
+
+  test('returns empty string for missing inputs', () => {
+    expect(formatTimeRange(null, '1:00 PM')).toBe('');
+  });
+});
+
+describe('formatLocationName', () => {
+  test('extracts room name from structured location', () => {
+    const location = 'Company - HQ - Conference Room A (Building 1)';
+    expect(formatLocationName(location)).toBe('Conference Room A');
+  });
+
+  test('falls back to original when structure missing', () => {
+    const location = 'Remote';
+    expect(formatLocationName(location)).toBe('Remote');
+  });
+});
+
+describe('getStatusFromEvent', () => {
+  test('detects lunch meetings', () => {
+    const event = { summary: 'Lunch with team' };
+    expect(getStatusFromEvent(event)).toBe('Out at Lunch');
+  });
+
+  test('detects focus time', () => {
+    const event = { summary: 'Focus Time - Deep work' };
+    expect(getStatusFromEvent(event)).toBe('Focus Time');
+  });
+
+  test('detects zoom meetings', () => {
+    const event = { summary: 'Weekly Sync', conferenceData: {} };
+    expect(getStatusFromEvent(event)).toBe('In a Zoom Meeting');
+  });
+
+  test('defaults to meeting', () => {
+    const event = { summary: 'Planning session' };
+    expect(getStatusFromEvent(event)).toBe('In a Meeting');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
         </div>
     </div>
 
+    <script src="public/helpers.js"></script>
     <script src="public/main.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "productivity-dashboard",
+  "version": "1.0.0",
+  "description": "This dashboard relies on several external APIs. Replace the placeholder `YOUR_*` values in `public/main.js` with your own keys.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/public/helpers.js
+++ b/public/helpers.js
@@ -1,0 +1,42 @@
+function formatTimeRange(start, end) {
+    if (!start || !end) return "";
+    const simplifyTime = (timeStr) => timeStr.replace(':00', '').toLowerCase();
+    let simpleStart = simplifyTime(start);
+    let simpleEnd = simplifyTime(end);
+    const startMeridian = simpleStart.includes('am') ? 'am' : 'pm';
+    const endMeridian = simpleEnd.includes('am') ? 'am' : 'pm';
+    if (startMeridian === endMeridian) {
+        simpleStart = simpleStart.replace(startMeridian, '').trim();
+    }
+    return `${simpleStart} - ${simpleEnd}`;
+}
+
+function formatLocationName(location) {
+    if (!location) return "";
+    const parts = location.split('-');
+    if (parts.length >= 3) {
+        let roomName = parts[2];
+        const parenIndex = roomName.indexOf('(');
+        if (parenIndex !== -1) {
+            roomName = roomName.substring(0, parenIndex).trim();
+        }
+        return roomName.trim();
+    }
+    return location;
+}
+
+function getStatusFromEvent(event) {
+    if (event.summary.toLowerCase().includes('lunch')) return 'Out at Lunch';
+    if (event.summary.toLowerCase().includes('focus time')) return 'Focus Time';
+    if (event.conferenceData) return 'In a Zoom Meeting';
+    return 'In a Meeting';
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { formatTimeRange, formatLocationName, getStatusFromEvent };
+}
+if (typeof window !== 'undefined') {
+    window.formatTimeRange = formatTimeRange;
+    window.formatLocationName = formatLocationName;
+    window.getStatusFromEvent = getStatusFromEvent;
+}

--- a/public/main.js
+++ b/public/main.js
@@ -136,12 +136,7 @@ document.addEventListener('DOMContentLoaded', function() {
             return null; 
         },
 
-        getStatusFromEvent(event) {
-            if (event.summary.toLowerCase().includes('lunch')) return 'Out at Lunch';
-            if (event.summary.toLowerCase().includes('focus time')) return 'Focus Time';
-            if (event.conferenceData) return 'In a Zoom Meeting';
-            return 'In a Meeting';
-        },
+        getStatusFromEvent,
 
         getFallbackStatus(hour) {
             let statusList;
@@ -405,32 +400,5 @@ document.addEventListener('DOMContentLoaded', function() {
         ]);
     }
     
-    function formatTimeRange(start, end) {
-        if (!start || !end) return "";
-        const simplifyTime = (timeStr) => timeStr.replace(':00', '').toLowerCase();
-        let simpleStart = simplifyTime(start);
-        let simpleEnd = simplifyTime(end);
-        const startMeridian = simpleStart.includes('am') ? 'am' : 'pm';
-        const endMeridian = simpleEnd.includes('am') ? 'am' : 'pm';
-        if (startMeridian === endMeridian) {
-            simpleStart = simpleStart.replace(startMeridian, '').trim();
-        }
-        return `${simpleStart} - ${simpleEnd}`;
-    }
-
-    function formatLocationName(location) {
-        if (!location) return "";
-        const parts = location.split('-');
-        if (parts.length >= 3) {
-            let roomName = parts[2];
-            const parenIndex = roomName.indexOf('(');
-            if (parenIndex !== -1) {
-                roomName = roomName.substring(0, parenIndex).trim();
-            }
-            return roomName;
-        }
-        return location;
-    }
-
     initializeApp();
 });


### PR DESCRIPTION
## Summary
- extract helper functions into `public/helpers.js` and expose them for testing
- add Jest tests for time, location, and status helpers
- document `npm test` and add CI workflow for automated testing

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4db20f18832f80fe8aea200e6657