### PR TITLE
Handle real-time calendar events with tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
         </div>
     </div>
 
+    <script src="public/status-utils.js"></script>
     <script src="public/main.js"></script>
 </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -131,29 +131,17 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             this.setStatus(this.getFallbackStatus(currentHour));
         },
-        
+
         getCurrentEvent(now) {
-            return null; 
+            return statusUtils.getCurrentEvent(now, currentCalendar);
         },
 
         getStatusFromEvent(event) {
-            if (event.summary.toLowerCase().includes('lunch')) return 'Out at Lunch';
-            if (event.summary.toLowerCase().includes('focus time')) return 'Focus Time';
-            if (event.conferenceData) return 'In a Zoom Meeting';
-            return 'In a Meeting';
+            return statusUtils.getStatusFromEvent(event);
         },
 
         getFallbackStatus(hour) {
-            let statusList;
-            if (hour >= 6 && hour < 8) statusList = config.statusConfig.fallback_statuses.early_morning;
-            else if (hour >= 8 && hour < 9) statusList = config.statusConfig.fallback_statuses.start_of_day;
-            else if (hour >= 16 && hour < 16.5) statusList = config.statusConfig.fallback_statuses.end_of_day;
-            else if (hour >= 16.5 && hour < 18) statusList = config.statusConfig.fallback_statuses.after_work;
-            else if (hour >= 18) statusList = config.statusConfig.fallback_statuses.evening;
-            else return 'Available';
-            
-            const index = Math.floor((Date.now() / 10000) % statusList.length);
-            return statusList[index];
+            return statusUtils.getFallbackStatus(hour, config);
         },
     };
 

--- a/public/status-utils.js
+++ b/public/status-utils.js
@@ -1,0 +1,82 @@
+(function(global) {
+  function parseTimeToDate(timeStr, referenceDate) {
+    if (!timeStr) return null;
+    const match = timeStr.match(/^(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$/i);
+    if (!match) return null;
+    let hours = parseInt(match[1], 10);
+    const minutes = parseInt(match[2] || '0', 10);
+    const period = match[3] ? match[3].toLowerCase() : null;
+    if (period) {
+      if (period === 'pm' && hours !== 12) hours += 12;
+      if (period === 'am' && hours === 12) hours = 0;
+    }
+    const date = new Date(referenceDate);
+    date.setHours(hours, minutes, 0, 0);
+    return date;
+  }
+
+  function isAllDay(event) {
+    return event.startTime === '12:00 am' && event.endTime === '12:00 am';
+  }
+
+  function getCurrentEvent(now, calendar) {
+    if (!Array.isArray(calendar)) return null;
+    for (const event of calendar) {
+      if (isAllDay(event)) {
+        const startOfDay = new Date(now);
+        startOfDay.setHours(0, 0, 0, 0);
+        const endOfDay = new Date(startOfDay);
+        endOfDay.setDate(endOfDay.getDate() + 1);
+        if (now >= startOfDay && now < endOfDay) {
+          return event;
+        }
+      } else {
+        const start = parseTimeToDate(event.startTime, now);
+        const end = parseTimeToDate(event.endTime, now);
+        if (start && end && start <= now && now < end) {
+          return event;
+        }
+      }
+    }
+    return null;
+  }
+
+  function getStatusFromEvent(event) {
+    if (!event || !event.summary) return 'In a Meeting';
+    const summary = event.summary.toLowerCase();
+    if (summary.includes('lunch')) return 'Out at Lunch';
+    if (summary.includes('focus time')) return 'Focus Time';
+    if (event.conferenceData) return 'In a Zoom Meeting';
+    return 'In a Meeting';
+  }
+
+  function getFallbackStatus(hour, config) {
+    const statuses = config.statusConfig.fallback_statuses;
+    let statusList;
+    if (hour >= 6 && hour < 8) statusList = statuses.early_morning;
+    else if (hour >= 8 && hour < 9) statusList = statuses.start_of_day;
+    else if (hour >= 16 && hour < 16.5) statusList = statuses.end_of_day;
+    else if (hour >= 16.5 && hour < 18) statusList = statuses.after_work;
+    else if (hour >= 18) statusList = statuses.evening;
+    else return 'Available';
+    const index = Math.floor((Date.now() / 10000) % statusList.length);
+    return statusList[index];
+  }
+
+  function evaluate(now, calendar, config, setStatus) {
+    const currentEvent = getCurrentEvent(now, calendar);
+    if (currentEvent) {
+      setStatus(getStatusFromEvent(currentEvent));
+      return;
+    }
+    setStatus(getFallbackStatus(now.getHours(), config));
+  }
+
+  const exportsObj = { getCurrentEvent, getStatusFromEvent, getFallbackStatus, evaluate };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = exportsObj;
+  } else {
+    global.statusUtils = exportsObj;
+  }
+})(this);

--- a/test/status-utils.test.js
+++ b/test/status-utils.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { getCurrentEvent, evaluate } = require('../public/status-utils.js');
+
+test('getCurrentEvent returns first overlapping event', () => {
+  const calendar = [
+    { startTime: '9:00 am', endTime: '10:00 am', summary: 'Event A' },
+    { startTime: '9:30 am', endTime: '10:30 am', summary: 'Event B' }
+  ];
+  const now = new Date();
+  now.setHours(9, 45, 0, 0);
+  const event = getCurrentEvent(now, calendar);
+  assert.strictEqual(event.summary, 'Event A');
+});
+
+test('getCurrentEvent handles all-day events', () => {
+  const calendar = [
+    { startTime: '12:00 am', endTime: '12:00 am', summary: 'All Day Event' }
+  ];
+  const now = new Date();
+  now.setHours(15, 0, 0, 0);
+  const event = getCurrentEvent(now, calendar);
+  assert.ok(event, 'Expected to find all-day event');
+  assert.strictEqual(event.summary, 'All Day Event');
+});
+
+test('evaluate triggers setStatus based on real events', () => {
+  const calendar = [
+    { startTime: '12:00 pm', endTime: '1:00 pm', summary: 'Lunch with team' }
+  ];
+  const now = new Date();
+  now.setHours(12, 30, 0, 0);
+  const config = { statusConfig: { fallback_statuses: {}, images: {} } };
+  let status = null;
+  function setStatus(s) { status = s; }
+  evaluate(now, calendar, config, setStatus);
+  assert.strictEqual(status, 'Out at Lunch');
+});


### PR DESCRIPTION
## Summary
- Detect active calendar events via `statusUtils` and surface them in status evaluation
- Wire status manager to use event-based status lookups
- Add tests covering overlapping and all-day events

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4d9b4e78832f824ab08d1469549e