### PR TITLE
Use env vars for API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
+.env
 

--- a/README.md
+++ b/README.md
@@ -13,17 +13,25 @@ This project began as a static HTML page and does not require a heavy front‑en
 
 ## API Configuration
 
-This dashboard relies on several external APIs. Replace the placeholder `YOUR_*` values in `src/main.js` with your own keys.
+This dashboard relies on several external APIs. Supply the required keys to Vite through a `.env` file in the project root:
+
+```
+VITE_WEATHERAPI_KEY=your_weatherapi_key
+VITE_GOOGLE_CALENDAR_API_KEY=your_google_calendar_api_key
+VITE_UNSPLASH_ACCESS_KEY=your_unsplash_access_key
+```
+
+These variables are read in `src/main.js` via `import.meta.env` and injected at build time.
 
 - **Weather**: [WeatherAPI](https://www.weatherapi.com/)
   - Endpoint: `https://api.weatherapi.com/v1/forecast.json`
-  - Key: `WEATHERAPI_KEY`
+  - Key: `VITE_WEATHERAPI_KEY`
 - **Events**: [Google Calendar API](https://developers.google.com/calendar)
   - Endpoint: `https://www.googleapis.com/calendar/v3/calendars/primary/events`
-  - Key: `GOOGLE_CALENDAR_API_KEY`
+  - Key: `VITE_GOOGLE_CALENDAR_API_KEY`
 - **Photos**: [Unsplash API](https://unsplash.com/developers)
   - Endpoint: `https://api.unsplash.com/photos/random`
-  - Key: `UNSPLASH_ACCESS_KEY`
+  - Key: `VITE_UNSPLASH_ACCESS_KEY`
 
 ### CORS
 

--- a/src/main.js
+++ b/src/main.js
@@ -9,10 +9,10 @@ document.addEventListener('DOMContentLoaded', function() {
         leftModuleMode: 'rotate', // Change to 'static' to disable rotation
         activeLeftModule: 'quote', // Used only if mode is 'static'
         quoteUrl: 'https://zenquotes.io/api/quotes/keyword=inspiration&maxLength=150',
-        weatherUrl: 'https://api.weatherapi.com/v1/forecast.json?key=YOUR_WEATHERAPI_KEY&q=Lehi&days=1&aqi=yes',
-        eventsUrl: 'https://www.googleapis.com/calendar/v3/calendars/primary/events?key=YOUR_GOOGLE_CALENDAR_API_KEY',
-        personalPhotosUrl: 'https://api.unsplash.com/photos/random?count=10&query=personal&client_id=YOUR_UNSPLASH_ACCESS_KEY',
-        companyPhotosUrl: 'https://api.unsplash.com/photos/random?count=10&query=office&client_id=YOUR_UNSPLASH_ACCESS_KEY',
+        weatherUrl: `https://api.weatherapi.com/v1/forecast.json?key=${import.meta.env.VITE_WEATHERAPI_KEY}&q=Lehi&days=1&aqi=yes`,
+        eventsUrl: `https://www.googleapis.com/calendar/v3/calendars/primary/events?key=${import.meta.env.VITE_GOOGLE_CALENDAR_API_KEY}`,
+        personalPhotosUrl: `https://api.unsplash.com/photos/random?count=10&query=personal&client_id=${import.meta.env.VITE_UNSPLASH_ACCESS_KEY}`,
+        companyPhotosUrl: `https://api.unsplash.com/photos/random?count=10&query=office&client_id=${import.meta.env.VITE_UNSPLASH_ACCESS_KEY}`,
         personalAlbum: { rotateSpeed: 5000, order: 'random', transition: 'fade', transitionSpeed: 1.5 },
         companyAlbum: { rotateSpeed: 10000, order: 'sequential', transition: 'fade', transitionSpeed: 1.5 },
         statusConfig: {


### PR DESCRIPTION
## Summary
- read WeatherAPI, Google Calendar API, and Unsplash credentials from Vite env variables instead of hardcoded placeholders
- document `.env` variables for API keys and ignore the file in git

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite: not found; `npm install` returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4ff1415c832f80db942ebe56e699