### PR TITLE
feat: externalize API configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+config.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,36 @@
 
 ## API Configuration
 
-This dashboard relies on several external APIs. Replace the placeholder `YOUR_*` values in `public/main.js` with your own keys.
+This dashboard relies on several external APIs. API keys and endpoints are read from a configuration module at runtime.
+Provide these values via environment variables or a local `config.json` file.
+
+### Environment variables
+
+Create a `.env` file and define the following values. Ensure your build process exposes them to the browser environment.
+
+```
+QUOTE_URL=
+WEATHER_URL=
+EVENTS_URL=
+PERSONAL_PHOTOS_URL=
+COMPANY_PHOTOS_URL=
+```
+
+### `config.json`
+
+Alternatively, create a `config.json` file at the project root:
+
+```
+{
+  "quoteUrl": "...",
+  "weatherUrl": "...",
+  "eventsUrl": "...",
+  "personalPhotosUrl": "...",
+  "companyPhotosUrl": "..."
+}
+```
+
+Both `.env` and `config.json` are ignored by git to keep secrets local.
 
 - **Weather**: [WeatherAPI](https://www.weatherapi.com/)
   - Endpoint: `https://api.weatherapi.com/v1/forecast.json`

--- a/index.html
+++ b/index.html
@@ -98,6 +98,6 @@
         </div>
     </div>
 
-    <script src="public/main.js"></script>
+    <script type="module" src="public/main.js"></script>
 </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,4 +1,8 @@
-document.addEventListener('DOMContentLoaded', function() {
+import { loadConfig } from '../src/config.js';
+
+document.addEventListener('DOMContentLoaded', async function() {
+
+    const apiConfig = await loadConfig();
     
     const config = {
         dashboardTitle: "Russell's Desk",
@@ -6,11 +10,11 @@ document.addEventListener('DOMContentLoaded', function() {
         dataRefreshInterval: 15 * 60 * 1000,
         leftModuleMode: 'rotate', // Change to 'static' to disable rotation
         activeLeftModule: 'quote', // Used only if mode is 'static'
-        quoteUrl: 'https://zenquotes.io/api/quotes/keyword=inspiration&maxLength=150',
-        weatherUrl: 'https://api.weatherapi.com/v1/forecast.json?key=YOUR_WEATHERAPI_KEY&q=Lehi&days=1&aqi=yes',
-        eventsUrl: 'https://www.googleapis.com/calendar/v3/calendars/primary/events?key=YOUR_GOOGLE_CALENDAR_API_KEY',
-        personalPhotosUrl: 'https://api.unsplash.com/photos/random?count=10&query=personal&client_id=YOUR_UNSPLASH_ACCESS_KEY',
-        companyPhotosUrl: 'https://api.unsplash.com/photos/random?count=10&query=office&client_id=YOUR_UNSPLASH_ACCESS_KEY',
+        quoteUrl: apiConfig.quoteUrl,
+        weatherUrl: apiConfig.weatherUrl,
+        eventsUrl: apiConfig.eventsUrl,
+        personalPhotosUrl: apiConfig.personalPhotosUrl,
+        companyPhotosUrl: apiConfig.companyPhotosUrl,
         personalAlbum: { rotateSpeed: 5000, order: 'random', transition: 'fade', transitionSpeed: 1.5 },
         companyAlbum: { rotateSpeed: 10000, order: 'sequential', transition: 'fade', transitionSpeed: 1.5 },
         statusConfig: {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,30 @@
+export async function loadConfig() {
+  const env = (typeof process !== 'undefined' && process.env) ? process.env : {};
+  if (
+    env.QUOTE_URL ||
+    env.WEATHER_URL ||
+    env.EVENTS_URL ||
+    env.PERSONAL_PHOTOS_URL ||
+    env.COMPANY_PHOTOS_URL
+  ) {
+    return {
+      quoteUrl: env.QUOTE_URL,
+      weatherUrl: env.WEATHER_URL,
+      eventsUrl: env.EVENTS_URL,
+      personalPhotosUrl: env.PERSONAL_PHOTOS_URL,
+      companyPhotosUrl: env.COMPANY_PHOTOS_URL
+    };
+  }
+
+  try {
+    const response = await fetch('/config.json');
+    if (response.ok) {
+      return await response.json();
+    }
+    console.warn('Config file not found or invalid');
+  } catch (err) {
+    console.error('Failed to load config.json', err);
+  }
+
+  return {};
+}


### PR DESCRIPTION
## Summary
- move API endpoints and keys to a dedicated config loader
- load runtime configuration in `public/main.js`
- document secure configuration via `.env` or `config.json`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab444e1f94832faccf5d7620bdc0dd