### PR TITLE
feat: integrate stock and news APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ WEATHER_URL=
 EVENTS_URL=
 PERSONAL_PHOTOS_URL=
 COMPANY_PHOTOS_URL=
+STOCK_URL=
+NEWS_URL=
 ```
 
 ### `config.json`
@@ -27,7 +29,9 @@ Alternatively, create a `config.json` file at the project root:
   "weatherUrl": "...",
   "eventsUrl": "...",
   "personalPhotosUrl": "...",
-  "companyPhotosUrl": "..."
+  "companyPhotosUrl": "...",
+  "stockUrl": "...",
+  "newsUrl": "..."
 }
 ```
 
@@ -42,6 +46,12 @@ Both `.env` and `config.json` are ignored by git to keep secrets local.
 - **Photos**: [Unsplash API](https://unsplash.com/developers)
   - Endpoint: `https://api.unsplash.com/photos/random`
   - Key: `UNSPLASH_ACCESS_KEY`
+- **Stocks**: [Alpha Vantage](https://www.alphavantage.co/)
+  - Endpoint: `https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol=IBM&apikey=YOUR_KEY`
+  - Key: `ALPHAVANTAGE_API_KEY`
+- **News**: [NewsAPI](https://newsapi.org/)
+  - Endpoint: `https://newsapi.org/v2/top-headlines?country=us&apiKey=YOUR_KEY`
+  - Key: `NEWSAPI_KEY`
 
 ### CORS
 

--- a/src/config.js
+++ b/src/config.js
@@ -5,14 +5,18 @@ export async function loadConfig() {
     env.WEATHER_URL ||
     env.EVENTS_URL ||
     env.PERSONAL_PHOTOS_URL ||
-    env.COMPANY_PHOTOS_URL
+    env.COMPANY_PHOTOS_URL ||
+    env.STOCK_URL ||
+    env.NEWS_URL
   ) {
     return {
       quoteUrl: env.QUOTE_URL,
       weatherUrl: env.WEATHER_URL,
       eventsUrl: env.EVENTS_URL,
       personalPhotosUrl: env.PERSONAL_PHOTOS_URL,
-      companyPhotosUrl: env.COMPANY_PHOTOS_URL
+      companyPhotosUrl: env.COMPANY_PHOTOS_URL,
+      stockUrl: env.STOCK_URL,
+      newsUrl: env.NEWS_URL
     };
   }
 


### PR DESCRIPTION
## Summary
- document Alpha Vantage and NewsAPI configuration details
- pull real stock and news data via `fetchWithMock`
- show fallback messages when stock or news data is unavailable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab46588730832f97b683e7a7e5c1b9