### PR TITLE
Add local proxy server for API requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 config.json
+node_modules/

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Both `.env` and `config.json` are ignored by git to keep secrets local.
   - Endpoint: `https://newsapi.org/v2/top-headlines?country=us&apiKey=YOUR_KEY`
   - Key: `NEWSAPI_KEY`
 
-### CORS
+### Local proxy
 
-Requests are proxied through `https://cors-anywhere.herokuapp.com/`. You may need to request temporary access from that service for local development or configure your own proxy.
+Run the built-in Node server to serve the dashboard and forward API requests with appropriate CORS headers:
+
+1. Install dependencies: `npm install`
+2. Start the server: `npm start`
+3. Access the app at `http://localhost:3000`
+
+The client fetches data through `/api/proxy?url=...`, which relays requests to the configured third-party APIs.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "productivity-dashboard",
+  "version": "1.0.0",
+  "description": "This dashboard relies on several external APIs. API keys and endpoints are read from a configuration module at runtime. Provide these values via environment variables or a local `config.json` file.",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/public/main.js
+++ b/public/main.js
@@ -80,7 +80,7 @@ document.addEventListener('DOMContentLoaded', async function() {
 
     async function fetchWithMock(url, mockData = null) {
         try {
-            const proxyUrl = `https://cors-anywhere.herokuapp.com/${url}`;
+            const proxyUrl = `/api/proxy?url=${encodeURIComponent(url)}`;
             const response = await fetch(proxyUrl);
             if (!response.ok) {
                 const errorText = await response.text();

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,27 @@
+const express = require('express');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Serve static files from the project root
+app.use(express.static('.'));
+
+app.get('/api/proxy', async (req, res) => {
+  const targetUrl = req.query.url;
+  if (!targetUrl) {
+    return res.status(400).send('Missing url parameter');
+  }
+  try {
+    const response = await fetch(targetUrl);
+    const body = await response.text();
+    res.set('Access-Control-Allow-Origin', '*');
+    res.set('Content-Type', response.headers.get('content-type') || 'application/json');
+    res.status(response.status).send(body);
+  } catch (err) {
+    res.status(500).send(`Proxy request failed: ${err.message}`);
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Replace external CORS proxy with internal `/api/proxy` endpoint in `fetchWithMock`
- Introduce Node/Express server that serves the dashboard and forwards API requests with CORS headers
- Document proxy setup and add npm start script for local development

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68ab47dc4b9c832f8de6ad3a68f58819