### PR TITLE
Add selectable news modes with rotating headlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,11 @@
                 </div>
             </div>
              <div id="news-module" class="dashboard-module p-3" style="display: none;">
-                <h3 class="module-title text-[2vh]">Top Headline</h3>
+                <select id="news-mode" class="module-title text-[2vh]">
+                  <option value="headlines">Top Headlines</option>
+                  <option value="ai">AI News</option>
+                  <option value="politics">US Politics</option>
+                </select>
                 <p id="news-headline" class="text-[1.7vh] leading-tight font-light text-slate-200 flex-grow text-center"></p>
             </div>
 


### PR DESCRIPTION
## Summary
- Replace static news header with dropdown to select headlines, AI, or US politics.
- Implement news fetching and 10-second headline rotation with periodic refresh.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abc63368dc832fbd07e6d2559c56e5