### PR TITLE
Handle array responses in fetchNews

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -145,7 +145,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         try {
             const response = await fetch(`${config.newsUrl}?mode=${mode}`);
             const data = await response.json();
-            newsArticles = data?.articles || [];
+            newsArticles = Array.isArray(data) ? data : (data?.articles || []);
             if (newsIndex >= newsArticles.length) {
                 newsIndex = 0;
             }


### PR DESCRIPTION
## Summary
- Make fetchNews resilient to news API responses that return either arrays or objects with an `articles` field.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abcb770538832f8ede0c95903efd17