### PR TITLE
Wrap left modules in container and adjust grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,24 +30,26 @@
             </div>
             
             <!-- Interchangeable Modules -->
-            <div id="quote-module" class="dashboard-module p-3">
-                 <p id="quote-text" class="text-[1.7vh] leading-tight font-light text-slate-200 flex-grow"></p>
-                 <p id="quote-author" class="text-right text-slate-400 text-[1.4vh] mt-2"></p>
-            </div>
-            <div id="stock-module" class="dashboard-module p-3" style="display: none;">
-                <h3 class="module-title text-[2vh]">SPY</h3>
-                <div class="text-center">
-                    <p id="stock-price" class="stock-price">---.--</p>
-                    <p id="stock-change" class="text-[1.8vh]">-.-- (-.--%)</p>
+            <div id="left-module" class="dashboard-module p-3">
+                <div id="quote-module" class="active">
+                    <p id="quote-text" class="text-[1.7vh] leading-tight font-light text-slate-200 flex-grow"></p>
+                    <p id="quote-author" class="text-right text-slate-400 text-[1.4vh] mt-2"></p>
                 </div>
-            </div>
-             <div id="news-module" class="dashboard-module p-3" style="display: none;">
-                <select id="news-mode" class="module-title text-[2vh]">
-                  <option value="headlines">Top Headlines</option>
-                  <option value="ai">AI News</option>
-                  <option value="politics">US Politics</option>
-                </select>
-                <p id="news-headline" class="text-[1.7vh] leading-tight font-light text-slate-200 flex-grow text-center"></p>
+                <div id="stock-module">
+                    <h3 class="module-title text-[2vh]">SPY</h3>
+                    <div class="text-center">
+                        <p id="stock-price" class="stock-price">---.--</p>
+                        <p id="stock-change" class="text-[1.8vh]">-.-- (-.--%)</p>
+                    </div>
+                </div>
+                <div id="news-module">
+                    <select id="news-mode" class="module-title text-[2vh]">
+                      <option value="headlines">Top Headlines</option>
+                      <option value="ai">AI News</option>
+                      <option value="politics">US Politics</option>
+                    </select>
+                    <p id="news-headline" class="text-[1.7vh] leading-tight font-light text-slate-200 flex-grow text-center"></p>
+                </div>
             </div>
 
             <div id="weather-module" class="dashboard-module p-3 justify-between">

--- a/public/main.js
+++ b/public/main.js
@@ -178,18 +178,18 @@ document.addEventListener('DOMContentLoaded', async function() {
     }
 
     async function updateLeftModule() {
-        elements.quoteModule.style.display = 'none';
-        elements.stockModule.style.display = 'none';
-        elements.newsModule.style.display = 'none';
+        elements.quoteModule.classList.remove('active');
+        elements.stockModule.classList.remove('active');
+        elements.newsModule.classList.remove('active');
 
         if (config.activeLeftModule === 'quote') {
-            elements.quoteModule.style.display = 'flex';
+            elements.quoteModule.classList.add('active');
             await updateQuote();
         } else if (config.activeLeftModule === 'stock') {
-            elements.stockModule.style.display = 'flex';
+            elements.stockModule.classList.add('active');
             await updateStock();
         } else if (config.activeLeftModule === 'news') {
-            elements.newsModule.style.display = 'flex';
+            elements.newsModule.classList.add('active');
             rotateNews();
         }
     }

--- a/public/styles.css
+++ b/public/styles.css
@@ -19,7 +19,7 @@ body {
 #main-grid {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: 1.2fr min-content 2fr 2fr;
+    grid-template-rows: 1.2fr 1fr 2fr 2fr;
     width: 100%;
     height: 100%;
     border: 2px solid rgba(255, 255, 255, 0.2);
@@ -78,11 +78,22 @@ body {
     justify-content: center;
     align-items: center;
 }
+#left-module {
+    position: relative;
+}
+#left-module > div {
+    position: absolute;
+    inset: 0;
+    display: none;
+}
+#left-module > div.active {
+    display: flex;
+}
 #quote-text {
     text-align: center;
 }
 #quote-author {
-    flex-shrink: 0; 
+    flex-shrink: 0;
 }
 
 


### PR DESCRIPTION
## Summary
- Nest quote, stock, and news blocks inside new `left-module` container
- Use fractional second grid row and add absolute-positioned module styles
- Toggle `active` class in JavaScript to show current left module

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abcc7521e8832fa79192b83b1546ef