### PR TITLE
Limit news articles and reduce API page size

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -177,6 +177,7 @@ document.addEventListener('DOMContentLoaded', async function() {
             const response = await fetch(`${config.newsUrl}?mode=${mode}`);
             const data = await response.json();
             newsArticles = Array.isArray(data) ? data : (data?.articles || []);
+            newsArticles = newsArticles.slice(0, 5);
             if (newsIndex >= newsArticles.length) {
                 newsIndex = 0;
             }

--- a/server/index.js
+++ b/server/index.js
@@ -1,10 +1,13 @@
 const express = require('express');
+const newsProxy = require('./news');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 // Serve static files from the project root
 app.use(express.static('.'));
+
+app.get('/api/news', newsProxy);
 
 app.get('/api/proxy', async (req, res) => {
   const targetUrl = req.query.url;

--- a/server/news.js
+++ b/server/news.js
@@ -1,0 +1,23 @@
+const PAGE_SIZE = 5;
+
+module.exports = async function newsProxy(req, res) {
+  const pageSize = Number(req.query.pageSize) || PAGE_SIZE;
+  const mode = req.query.mode || 'headlines';
+  const apiKey = process.env.NEWSAPI_KEY;
+
+  let url;
+  if (mode === 'headlines') {
+    url = `https://newsapi.org/v2/top-headlines?country=us&pageSize=${pageSize}&apiKey=${apiKey}`;
+  } else {
+    url = `https://newsapi.org/v2/everything?q=${encodeURIComponent(mode)}&pageSize=${pageSize}&apiKey=${apiKey}`;
+  }
+
+  try {
+    const response = await fetch(url);
+    const data = await response.json();
+    res.set('Access-Control-Allow-Origin', '*');
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};


### PR DESCRIPTION
## Summary
- Limit displayed news articles to a maximum of five.
- Add a dedicated News API proxy with smaller page size and register it with the server.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abd7a4d410832f86c7b720e3b9ac45