### PR TITLE
feat: lengthen news rotation interval

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -265,7 +265,8 @@ document.addEventListener('DOMContentLoaded', async function() {
           activeIntervals.push(setInterval(updateStock, 60 * 1000));
 
         await fetchNews(currentMode);
-        activeIntervals.push(setInterval(rotateNews, 10 * 1000));
+        // Rotate through news headlines every 30 seconds
+        activeIntervals.push(setInterval(rotateNews, 30 * 1000));
         activeIntervals.push(setInterval(() => fetchNews(currentMode), 5 * 60 * 1000));
 
         await createSlideshow(elements.personalAlbumContainer, config.personalAlbum, config.personalPhotosUrl, fetchWithMock, activeIntervals);


### PR DESCRIPTION
## Summary
- rotate news headlines every 30 seconds instead of 10
- document new 30-second interval in code comment

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abd7ec259c832facabf5e588da9f17