### PR TITLE
Rename left module to info module

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
                 </div>
             </div>
             
-            <!-- Interchangeable Modules -->
-            <div id="left-module" class="dashboard-module p-3">
+            <!-- Info Module -->
+            <div id="info-module" class="dashboard-module p-3">
                 <div id="quote-module" class="active">
                     <p id="quote-text" class="text-[1.7vh] leading-tight font-light text-slate-200 flex-grow"></p>
                     <p id="quote-author" class="text-right text-slate-400 text-[1.4vh] mt-2"></p>

--- a/public/main.js
+++ b/public/main.js
@@ -14,8 +14,8 @@ document.addEventListener('DOMContentLoaded', async function() {
         dashboardTitle: "Russell's Desk",
         profileImageUrl: "https://www.dropbox.com/scl/fi/7fsfrr4yixqmmh0i0p67p/C2E599B7-FF0F-4740-8EB0-BD57C60723AB.jpg?rlkey=pawp5kwzu81n1hrqzxxric8lm&st=b2yrbs29&raw=1",
         dataRefreshInterval: 15 * 60 * 1000,
-        leftModuleMode: 'rotate',
-        activeLeftModule: 'quote',
+        infoModuleMode: 'rotate',
+        activeInfoModule: 'quote',
         quoteUrl: apiConfig.quoteUrl,
         weatherUrl: apiConfig.weatherUrl,
         eventsUrl: apiConfig.eventsUrl,
@@ -210,34 +210,34 @@ document.addEventListener('DOMContentLoaded', async function() {
         elements.profileImage.src = config.profileImageUrl;
     }
 
-    async function updateLeftModule() {
+    async function updateInfoModule() {
         elements.quoteModule.classList.remove('active');
         elements.stockModule.classList.remove('active');
         elements.newsModule.classList.remove('active');
 
-        if (config.activeLeftModule === 'quote') {
+        if (config.activeInfoModule === 'quote') {
             elements.quoteModule.classList.add('active');
             renderQuote();
-        } else if (config.activeLeftModule === 'stock') {
+        } else if (config.activeInfoModule === 'stock') {
             elements.stockModule.classList.add('active');
             await updateStock();
-        } else if (config.activeLeftModule === 'news') {
+        } else if (config.activeInfoModule === 'news') {
             elements.newsModule.classList.add('active');
             rotateNews();
         }
     }
 
-    function cycleLeftModule() {
+    function cycleInfoModule() {
         const modules = ['quote', 'stock', 'news'];
-        const currentIndex = modules.indexOf(config.activeLeftModule);
-        config.activeLeftModule = modules[(currentIndex + 1) % modules.length];
-        updateLeftModule();
+        const currentIndex = modules.indexOf(config.activeInfoModule);
+        config.activeInfoModule = modules[(currentIndex + 1) % modules.length];
+        updateInfoModule();
     }
 
     [elements.quoteModule, elements.stockModule, elements.newsModule].forEach(module => {
         if (module) {
-            module.addEventListener('click', cycleLeftModule);
-            module.addEventListener('touchstart', cycleLeftModule);
+            module.addEventListener('click', cycleInfoModule);
+            module.addEventListener('touchstart', cycleInfoModule);
         }
     });
 
@@ -245,7 +245,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         const [calendar] = await Promise.all([
             updateEvents(config, elements, fetchWithMock, activeIntervals),
             updateWeather(config, elements, fetchWithMock),
-            updateLeftModule()
+            updateInfoModule()
         ]);
         currentCalendar = calendar;
         statusManager.evaluate(currentCalendar);
@@ -275,8 +275,8 @@ document.addEventListener('DOMContentLoaded', async function() {
         activeIntervals.push(setInterval(fetchAllData, config.dataRefreshInterval));
         activeIntervals.push(setInterval(() => updateMasterStatus(statusManager, currentCalendar), 5000));
 
-        if (config.leftModuleMode === 'rotate') {
-            activeIntervals.push(setInterval(cycleLeftModule, 60000));
+        if (config.infoModuleMode === 'rotate') {
+            activeIntervals.push(setInterval(cycleInfoModule, 60000));
         }
     }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -78,15 +78,15 @@ body {
     justify-content: center;
     align-items: center;
 }
-#left-module {
+#info-module {
     position: relative;
 }
-#left-module > div {
+#info-module > div {
     position: absolute;
     inset: 0;
     display: none;
 }
-#left-module > div.active {
+#info-module > div.active {
     display: flex;
 }
 #quote-text {


### PR DESCRIPTION
## Summary
- Rename left module container to info module in HTML and CSS
- Update JavaScript logic and config to use infoModule naming
- Align comments and selectors with new info module ID

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abd8087dc8832fa0ed8aed605605ff