### PR TITLE
Handle stock change fallback with empty string

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -157,7 +157,7 @@ document.addEventListener('DOMContentLoaded', async function() {
               const parsedChangePct = parseFloat(changePct);
               if (isNaN(parsedPrice) || isNaN(parsedChange) || isNaN(parsedChangePct)) {
                   elements.stockPrice.textContent = '--';
-                  elements.stockChange.textContent = '--';
+                  elements.stockChange.textContent = '';
                   elements.stockChange.className = 'text-[1.8vh] stock-change';
                   return;
               }
@@ -168,7 +168,7 @@ document.addEventListener('DOMContentLoaded', async function() {
           } catch (error) {
               console.error('Fetch error:', error);
               elements.stockPrice.textContent = '--';
-              elements.stockChange.textContent = '--';
+              elements.stockChange.textContent = '';
               elements.stockChange.className = 'text-[1.8vh] stock-change';
           }
       }


### PR DESCRIPTION
## Summary
- reset `stockChange` display to empty string on invalid or failed stock data
- retain existing `console.error` logging without rethrow

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abdd6db288832fb95956a5405281ed