### PR TITLE
Use flex column layout for info modules

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -81,10 +81,13 @@ body {
     padding: 0;
 }
 
-/* Centering for interchangeable modules */
+/* Layout for interchangeable modules */
 #quote-module, #stock-module, #news-module {
-    justify-content: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
     align-items: center;
+    text-align: center;
 }
 #info-module {
     position: relative;


### PR DESCRIPTION
## Summary
- apply flexbox column layout to quote, stock, and news modules
- maintain text centering while allowing modules to align from the top

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abe16f089c832f91d047b360ad63d6