### PR TITLE
Ensure info module padding and responsive text

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
             </div>
             
             <!-- Info Module -->
-            <div id="info-module" class="dashboard-module p-3">
+            <div id="info-module" class="dashboard-module">
                 <div id="quote-module" class="active">
                     <p id="quote-text" class="text-[1.7vh] leading-tight font-light text-slate-200 flex-grow"></p>
                     <p id="quote-author" class="text-right text-slate-400 text-[1.4vh] mt-2"></p>

--- a/public/main.js
+++ b/public/main.js
@@ -108,18 +108,18 @@ document.addEventListener('DOMContentLoaded', async function() {
         elements.date.textContent = now.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
     }
 
-    function fitText(el, maxVH, minVH) {
+    function fitText(el, maxVH, minVH, container = el.parentElement) {
         if (!el) return;
         let size = maxVH;
         el.style.fontSize = `${size}vh`;
         el.style.wordBreak = 'break-word';
-        while (size > minVH && el.scrollHeight > el.parentElement.clientHeight) {
+        while (size > minVH && container.scrollHeight > container.clientHeight) {
             size -= 0.1;
             el.style.fontSize = `${size}vh`;
         }
-        if (el.scrollHeight > el.parentElement.clientHeight) {
+        if (container.scrollHeight > container.clientHeight) {
             let text = el.textContent;
-            while (text.length > 0 && el.scrollHeight > el.parentElement.clientHeight) {
+            while (text.length > 0 && container.scrollHeight > container.clientHeight) {
                 text = text.trim().slice(0, -1);
                 el.textContent = text + '…';
             }
@@ -129,7 +129,7 @@ document.addEventListener('DOMContentLoaded', async function() {
     function renderQuote() {
         elements.quoteText.textContent = lastQuote?.text || "--";
         elements.quoteAuthor.textContent = lastQuote?.author ? `- ${lastQuote.author}` : "";
-        fitText(elements.quoteText, 2.5, 1.2);
+        fitText(elements.quoteText, 2.5, 1.2, elements.quoteModule);
     }
 
     async function updateQuote() {
@@ -187,7 +187,8 @@ document.addEventListener('DOMContentLoaded', async function() {
             console.error('Fetch error:', error);
             newsArticles = [];
             elements.newsHeadline.textContent = 'News unavailable';
-            fitText(elements.newsHeadline, 2.5, 1.2);
+            fitText(elements.newsHeadline, 2.5, 1.2, elements.newsModule);
+            fitText(elements.newsMode, 2, 1.2, elements.newsModule);
         }
     }
 
@@ -195,15 +196,18 @@ document.addEventListener('DOMContentLoaded', async function() {
         try {
             if (newsArticles.length === 0) {
                 elements.newsHeadline.textContent = 'News unavailable';
-                fitText(elements.newsHeadline, 2.5, 1.2);
+                fitText(elements.newsHeadline, 2.5, 1.2, elements.newsModule);
+                fitText(elements.newsMode, 2, 1.2, elements.newsModule);
                 return;
             }
             elements.newsHeadline.textContent = newsArticles[newsIndex]?.title || 'News unavailable';
-            fitText(elements.newsHeadline, 2.5, 1.2);
+            fitText(elements.newsHeadline, 2.5, 1.2, elements.newsModule);
+            fitText(elements.newsMode, 2, 1.2, elements.newsModule);
             newsIndex = (newsIndex + 1) % newsArticles.length;
         } catch (error) {
             elements.newsHeadline.textContent = 'News unavailable';
-            fitText(elements.newsHeadline, 2.5, 1.2);
+            fitText(elements.newsHeadline, 2.5, 1.2, elements.newsModule);
+            fitText(elements.newsMode, 2, 1.2, elements.newsModule);
             console.error(error);
             return;
         }

--- a/public/styles.css
+++ b/public/styles.css
@@ -96,6 +96,8 @@ body {
     position: absolute;
     inset: 0;
     display: none;
+    padding: 0.75rem;
+    box-sizing: border-box;
 }
 #info-module > div.active {
     display: flex;


### PR DESCRIPTION
## Summary
- give each info submodule its own padding so content respects a 12px margin
- resize quote and news text to stay within their module boundaries

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abe36320b8832fa711a259accb263e