### PR TITLE
Handle weather fetch errors

### DIFF
--- a/public/modules/weather/index.js
+++ b/public/modules/weather/index.js
@@ -1,14 +1,27 @@
 export async function updateWeather(config, elements, fetchWithMock) {
-    const data = await fetchWithMock(config.weatherUrl);
-    if (data && data.current && data.location) {
-        const forecastDay = data.forecast?.forecastday?.[0]?.day || {};
-        elements.weatherLocation.textContent = data.location.name || 'Unknown';
-        elements.weatherTemp.textContent = `${Math.round(data.current.temp_f)}°`;
-        elements.weatherHighLow.textContent = `H:${Math.round(forecastDay.maxtemp_f || data.current.temp_f)}° L:${Math.round(forecastDay.mintemp_f || data.current.temp_f)}°`;
-        elements.uvIndex.textContent = data.current.uv ?? '--';
-        elements.aqiValue.textContent = data.current.air_quality?.['us-epa-index'] ?? '--';
-        elements.humidityValue.textContent = `${data.current.humidity}%`;
-        elements.weatherIcon.innerHTML = getWeatherIcon(data.current.condition.text);
+    try {
+        const data = await fetchWithMock(config.weatherUrl);
+        if (data && data.current && data.location) {
+            const forecastDay = data.forecast?.forecastday?.[0]?.day || {};
+            elements.weatherLocation.textContent = data.location.name || 'Unknown';
+            elements.weatherTemp.textContent = `${Math.round(data.current.temp_f)}°`;
+            elements.weatherHighLow.textContent = `H:${Math.round(forecastDay.maxtemp_f || data.current.temp_f)}° L:${Math.round(forecastDay.mintemp_f || data.current.temp_f)}°`;
+            elements.uvIndex.textContent = data.current.uv ?? '--';
+            elements.aqiValue.textContent = data.current.air_quality?.['us-epa-index'] ?? '--';
+            elements.humidityValue.textContent = `${data.current.humidity}%`;
+            elements.weatherIcon.innerHTML = getWeatherIcon(data.current.condition.text);
+        } else {
+            throw new Error('Incomplete weather data');
+        }
+    } catch (err) {
+        console.error('Failed to fetch weather data:', err);
+        elements.weatherLocation.textContent = '--';
+        elements.weatherTemp.textContent = '--';
+        elements.weatherHighLow.textContent = '--';
+        elements.uvIndex.textContent = '--';
+        elements.aqiValue.textContent = '--';
+        elements.humidityValue.textContent = '--';
+        elements.weatherIcon.innerHTML = '';
     }
 }
 


### PR DESCRIPTION
## Summary
- wrap weather data fetch in try/catch
- reset weather display on errors or missing fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abfb8b8534832fbed6794a8d6855d5