### PR TITLE
docs: update weather proxy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Create a `.env` file and define the following values. Ensure your build process 
 ```
 PROXY_BASE_URL=https://vercel-proxy-bananadona.vercel.app
 QUOTE_URL=
-WEATHER_URL=
 EVENTS_URL=
 PERSONAL_PHOTOS_URL=
 COMPANY_PHOTOS_URL=
@@ -25,10 +24,9 @@ NEWS_URL=
 Alternatively, create a `config.json` file at the project root:
 
 ```
-{
+{ 
   "proxyBaseUrl": "https://vercel-proxy-bananadona.vercel.app",
   "quoteUrl": "...",
-  "weatherUrl": "...",
   "eventsUrl": "...",
   "personalPhotosUrl": "...",
   "companyPhotosUrl": "...",
@@ -39,9 +37,7 @@ Alternatively, create a `config.json` file at the project root:
 
 Both `.env` and `config.json` are ignored by git to keep secrets local.
 
-- **Weather**: [WeatherAPI](https://www.weatherapi.com/)
-  - Endpoint: `https://api.weatherapi.com/v1/forecast.json`
-  - Key: `WEATHERAPI_KEY`
+- **Weather**: Browser requests are proxied through `https://vercel-proxy-bananadona.vercel.app/api/weather`. No API keys are stored in this repo.
 - **Events**: [Google Calendar API](https://developers.google.com/calendar)
   - Endpoint: `https://www.googleapis.com/calendar/v3/calendars/primary/events`
   - Key: `GOOGLE_CALENDAR_API_KEY`
@@ -63,4 +59,4 @@ Run the built-in Node server to serve the dashboard and forward API requests wit
 2. Start the server: `npm start`
 3. Access the app at `http://localhost:3000`
 
-The client fetches data through `/api/proxy?url=...`, which relays requests to the configured third-party APIs.
+The client fetches data through `/api/proxy?url=...`, which relays requests to the configured third-party APIs. Other modules may still use `/api/proxy`, but weather requests should call `/api/weather`, which forwards to the dedicated proxy endpoint.


### PR DESCRIPTION
## Summary
- drop WEATHER_URL env/config references
- document dedicated weather proxy endpoint
- note other modules may use `/api/proxy`

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68abfbdf9208832fafaaa01c771a249f