### PR TITLE
Document weather URL configuration variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Provide these values via environment variables or a local `config.json` file.
 Create a `.env` file and define the following values. Ensure your build process exposes them to the browser environment.
 
 ```
-PROXY_BASE_URL=https://vercel-proxy-bananadona.vercel.app
 QUOTE_URL=
+WEATHER_URL=
 EVENTS_URL=
 PERSONAL_PHOTOS_URL=
 COMPANY_PHOTOS_URL=
@@ -24,9 +24,9 @@ NEWS_URL=
 Alternatively, create a `config.json` file at the project root:
 
 ```
-{ 
-  "proxyBaseUrl": "https://vercel-proxy-bananadona.vercel.app",
+{
   "quoteUrl": "...",
+  "weatherUrl": "...",
   "eventsUrl": "...",
   "personalPhotosUrl": "...",
   "companyPhotosUrl": "...",

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,6 @@
 export async function loadConfig() {
   const env = (typeof process !== 'undefined' && process.env) ? process.env : {};
   if (
-    env.PROXY_BASE_URL ||
     env.QUOTE_URL ||
     env.WEATHER_URL ||
     env.EVENTS_URL ||
@@ -11,7 +10,6 @@ export async function loadConfig() {
     env.NEWS_URL
   ) {
     return {
-      proxyBaseUrl: env.PROXY_BASE_URL,
       quoteUrl: env.QUOTE_URL,
       weatherUrl: env.WEATHER_URL,
       eventsUrl: env.EVENTS_URL,


### PR DESCRIPTION
## Summary
- remove obsolete proxy base URL settings from config and docs
- document WEATHER_URL option in env and config.json examples
- streamline config loader to read current variables only

## Testing
- ❌ `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68abff915a9c832fb1de46507a723c66