### PR TITLE
docs: point WEATHER_URL directly to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Provide these values via environment variables or a local `config.json` file.
 Create a `.env` file and define the following values. Ensure your build process exposes them to the browser environment.
 
 ```
-PROXY_BASE_URL=https://vercel-proxy-bananadona.vercel.app
+PROXY_BASE_URL=https://your-proxy.example.com
+WEATHER_URL=
 QUOTE_URL=
 EVENTS_URL=
 PERSONAL_PHOTOS_URL=
@@ -24,8 +25,9 @@ NEWS_URL=
 Alternatively, create a `config.json` file at the project root:
 
 ```
-{ 
-  "proxyBaseUrl": "https://vercel-proxy-bananadona.vercel.app",
+{
+  "proxyBaseUrl": "https://your-proxy.example.com",
+  "weatherUrl": "...",
   "quoteUrl": "...",
   "eventsUrl": "...",
   "personalPhotosUrl": "...",
@@ -37,7 +39,7 @@ Alternatively, create a `config.json` file at the project root:
 
 Both `.env` and `config.json` are ignored by git to keep secrets local.
 
-- **Weather**: Browser requests are proxied through `https://vercel-proxy-bananadona.vercel.app/api/weather`. No API keys are stored in this repo.
+- **Weather**: Set `WEATHER_URL` to the direct weather API endpoint you plan to use. The URL should include any required API key or query parameters.
 - **Events**: [Google Calendar API](https://developers.google.com/calendar)
   - Endpoint: `https://www.googleapis.com/calendar/v3/calendars/primary/events`
   - Key: `GOOGLE_CALENDAR_API_KEY`
@@ -59,4 +61,4 @@ Run the built-in Node server to serve the dashboard and forward API requests wit
 2. Start the server: `npm start`
 3. Access the app at `http://localhost:3000`
 
-The client fetches data through `/api/proxy?url=...`, which relays requests to the configured third-party APIs. Other modules may still use `/api/proxy`, but weather requests should call `/api/weather`, which forwards to the dedicated proxy endpoint.
+The client fetches data through `/api/proxy?url=...`, which relays requests to the configured third-party APIs.


### PR DESCRIPTION
## Summary
- clarify weather setup to use a direct `WEATHER_URL` endpoint with any required key
- remove references to Vercel proxy and `/api/weather`
- add `WEATHER_URL` to example environment and config files

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abff95a83c832f94fd0062f6a0ef56