### PR TITLE
docs: update proxy routes and weather instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Create a `.env` file and define the following values. Ensure your build process 
 ```
 PROXY_BASE_URL=https://vercel-proxy-bananadona.vercel.app
 QUOTE_URL=
+WEATHER_URL=
 EVENTS_URL=
 PERSONAL_PHOTOS_URL=
 COMPANY_PHOTOS_URL=
@@ -27,6 +28,7 @@ Alternatively, create a `config.json` file at the project root:
 { 
   "proxyBaseUrl": "https://vercel-proxy-bananadona.vercel.app",
   "quoteUrl": "...",
+  "weatherUrl": "...",
   "eventsUrl": "...",
   "personalPhotosUrl": "...",
   "companyPhotosUrl": "...",
@@ -37,7 +39,7 @@ Alternatively, create a `config.json` file at the project root:
 
 Both `.env` and `config.json` are ignored by git to keep secrets local.
 
-- **Weather**: Browser requests are proxied through `https://vercel-proxy-bananadona.vercel.app/api/weather`. No API keys are stored in this repo.
+- **Weather**: Requests use the `WEATHER_URL` endpoint directly. No API keys are stored in this repo.
 - **Events**: [Google Calendar API](https://developers.google.com/calendar)
   - Endpoint: `https://www.googleapis.com/calendar/v3/calendars/primary/events`
   - Key: `GOOGLE_CALENDAR_API_KEY`
@@ -59,4 +61,4 @@ Run the built-in Node server to serve the dashboard and forward API requests wit
 2. Start the server: `npm start`
 3. Access the app at `http://localhost:3000`
 
-The client fetches data through `/api/proxy?url=...`, which relays requests to the configured third-party APIs. Other modules may still use `/api/proxy`, but weather requests should call `/api/weather`, which forwards to the dedicated proxy endpoint.
+The client can forward requests through `/api/proxy?url=...` for generic third-party APIs. `/api/news` is available for NewsAPI calls. Weather requests bypass the proxy and use `WEATHER_URL` directly.


### PR DESCRIPTION
## Summary
- document `/api/proxy` and `/api/news` routes in Local proxy section
- explain that weather calls use `WEATHER_URL` directly
- add `WEATHER_URL` configuration examples

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abff963db4832f93f5541b300b2dbe