### PR TITLE
docs: note NEWSAPI key for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Both `.env` and `config.json` are ignored by git to keep secrets local.
 - **News**: [NewsAPI](https://newsapi.org/)
   - Endpoint: `https://newsapi.org/v2/top-headlines?country=us&apiKey=YOUR_KEY`
   - Key: `NEWSAPI_KEY`
+  - Set `NEWSAPI_KEY` in the server environment; the Node server reads this value when handling `/api/news` requests.
 
 ### Local proxy
 


### PR DESCRIPTION
## Summary
- document NEWSAPI_KEY requirement for the server news proxy

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68abff9820a8832f880df0f141e66b0d