### PR TITLE
Use proxy fetch for weather data

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -260,7 +260,7 @@ document.addEventListener('DOMContentLoaded', async function() {
     async function fetchAllData() {
         const [calendar] = await Promise.all([
             updateEvents(config, elements, fetchWithMock, activeIntervals),
-            updateWeather(config, elements),
+            updateWeather(config, elements, fetchWithMock),
             updateInfoModule()
         ]);
         currentCalendar = calendar;

--- a/public/modules/weather/index.js
+++ b/public/modules/weather/index.js
@@ -1,10 +1,21 @@
-export async function updateWeather(config, elements) {
+export async function updateWeather(config, elements, fetchWithMock) {
+    if (!config?.weatherUrl) {
+        resetFields();
+        return;
+    }
+
     try {
-        const response = await fetch(config.weatherUrl);
-        if (!response.ok) {
-            throw new Error(`Request failed with status ${response.status}`);
+        let data;
+        if (typeof fetchWithMock === 'function') {
+            data = await fetchWithMock(config.weatherUrl);
+        } else {
+            const response = await fetch(config.weatherUrl);
+            if (!response.ok) {
+                throw new Error(`Request failed with status ${response.status}`);
+            }
+            data = await response.json();
         }
-        const data = await response.json();
+
         if (data && data.current && data.location) {
             const forecastDay = data.forecast?.forecastday?.[0]?.day || {};
             elements.weatherLocation.textContent = data.location.name || 'Unknown';


### PR DESCRIPTION
## Summary
- use provided proxy fetch helper when requesting weather data
- handle missing weather URL gracefully

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac042af23c832fa8a9230922964da1