### PR TITLE
Overlay environment variables on config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,34 +1,25 @@
 export async function loadConfig() {
   const env = (typeof process !== 'undefined' && process.env) ? process.env : {};
-  if (
-    env.QUOTE_URL ||
-    env.WEATHER_URL ||
-    env.EVENTS_URL ||
-    env.PERSONAL_PHOTOS_URL ||
-    env.COMPANY_PHOTOS_URL ||
-    env.STOCK_URL ||
-    env.NEWS_URL
-  ) {
-    return {
-      quoteUrl: env.QUOTE_URL,
-      weatherUrl: env.WEATHER_URL,
-      eventsUrl: env.EVENTS_URL,
-      personalPhotosUrl: env.PERSONAL_PHOTOS_URL,
-      companyPhotosUrl: env.COMPANY_PHOTOS_URL,
-      stockUrl: env.STOCK_URL,
-      newsUrl: env.NEWS_URL
-    };
-  }
+  let config = {};
 
   try {
     const response = await fetch('/config.json');
     if (response.ok) {
-      return await response.json();
+      config = await response.json();
+    } else {
+      console.warn('Config file not found or invalid');
     }
-    console.warn('Config file not found or invalid');
   } catch (err) {
     console.error('Failed to load config.json', err);
   }
 
-  return {};
+  if (env.QUOTE_URL) config.quoteUrl = env.QUOTE_URL;
+  if (env.WEATHER_URL) config.weatherUrl = env.WEATHER_URL;
+  if (env.EVENTS_URL) config.eventsUrl = env.EVENTS_URL;
+  if (env.PERSONAL_PHOTOS_URL) config.personalPhotosUrl = env.PERSONAL_PHOTOS_URL;
+  if (env.COMPANY_PHOTOS_URL) config.companyPhotosUrl = env.COMPANY_PHOTOS_URL;
+  if (env.STOCK_URL) config.stockUrl = env.STOCK_URL;
+  if (env.NEWS_URL) config.newsUrl = env.NEWS_URL;
+
+  return config;
 }


### PR DESCRIPTION
## Summary
- Load `/config.json` and overlay environment variables individually
- Ensure each env var overrides config only if defined
- Allow fields like `weatherUrl` to fall back to file when env vars missing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac83c5131c832f9307a8fa1325f409