### PR TITLE
Remove proxy from weather requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ Run the built-in Node server to serve the dashboard and forward API requests wit
 2. Start the server: `npm start`
 3. Access the app at `http://localhost:3000`
 
-The client can forward requests through `/api/proxy?url=...` for generic third-party APIs. `/api/news` is available for NewsAPI calls. Weather requests bypass the proxy and use `WEATHER_URL` directly.
+The client can forward requests through `/api/proxy?url=...` for generic third-party APIs. `/api/news` is available for NewsAPI calls. Weather requests now fetch directly from `WEATHER_URL` without using the proxy.

--- a/public/main.js
+++ b/public/main.js
@@ -263,7 +263,7 @@ document.addEventListener('DOMContentLoaded', async function() {
     async function fetchAllData() {
         const [calendar] = await Promise.all([
             updateEvents(config, elements, fetchWithMock, activeIntervals),
-            updateWeather(config, elements, fetchWithMock),
+            updateWeather(config, elements),
             updateInfoModule()
         ]);
         currentCalendar = calendar;

--- a/public/modules/weather/index.js
+++ b/public/modules/weather/index.js
@@ -1,20 +1,15 @@
-export async function updateWeather(config, elements, fetchWithMock) {
+export async function updateWeather(config, elements) {
     if (!config?.weatherUrl) {
         resetFields();
         return;
     }
 
     try {
-        let data;
-        if (typeof fetchWithMock === 'function') {
-            data = await fetchWithMock(config.weatherUrl);
-        } else {
-            const response = await fetch(config.weatherUrl);
-            if (!response.ok) {
-                throw new Error(`Request failed with status ${response.status}`);
-            }
-            data = await response.json();
+        const response = await fetch(config.weatherUrl);
+        if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
         }
+        const data = await response.json();
 
         if (data && data.current && data.location) {
             const forecastDay = data.forecast?.forecastday?.[0]?.day || {};


### PR DESCRIPTION
## Summary
- call `updateWeather` without proxy helper
- fetch weather data directly inside `updateWeather`
- document that weather requests no longer use the proxy

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac86885af0832fb7dde9319e824e16