### PR TITLE
Fix weather high/low fallback

### DIFF
--- a/public/modules/weather/index.js
+++ b/public/modules/weather/index.js
@@ -20,7 +20,7 @@ export async function updateWeather(config, elements, fetchWithMock) {
             const forecastDay = data.forecast?.forecastday?.[0]?.day || {};
             elements.weatherLocation.textContent = data.location.name || 'Unknown';
             elements.weatherTemp.textContent = `${Math.round(data.current.temp_f)}°`;
-            elements.weatherHighLow.textContent = `H:${Math.round(forecastDay.maxtemp_f || data.current.temp_f)}° L:${Math.round(forecastDay.mintemp_f || data.current.temp_f)}°`;
+            elements.weatherHighLow.textContent = `H:${Math.round(forecastDay.maxtemp_f ?? data.current.temp_f)}° L:${Math.round(forecastDay.mintemp_f ?? data.current.temp_f)}°`;
             elements.uvIndex.textContent = data.current.uv ?? '--';
             elements.aqiValue.textContent = data.current.air_quality?.['us-epa-index'] ?? '--';
             elements.humidityValue.textContent = `${data.current.humidity}%`;


### PR DESCRIPTION
## Summary
- Use nullish coalescing for forecast high/low temperatures so 0°F is displayed correctly

## Testing
- `node -e 'const forecastDay={maxtemp_f:0,mintemp_f:0}; const data={current:{temp_f:72}}; console.log(`H:${Math.round(forecastDay.maxtemp_f ?? data.current.temp_f)}° L:${Math.round(forecastDay.mintemp_f ?? data.current.temp_f)}°`);'`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8700d734832fb8e8d1d460004e6d