### PR TITLE
Specify Node 18 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Productivity Dashboard
 
+## Requirements
+
+- Node.js 18 or later. The server uses the built-in `fetch` API available in Node 18+.
+
 ## API Configuration
 
 This dashboard relies on several external APIs. API keys and endpoints are read from a configuration module at runtime.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "author": "",
   "license": "ISC",
   "type": "commonjs",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "express": "^4.19.2"
   }


### PR DESCRIPTION
## Summary
- declare Node.js 18+ requirement in package.json engines
- document Node 18 prerequisite in README to avoid deployment mismatches

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac87696584832f9332e2f206bffb59