### PR TITLE
feat: host scout network under subpath

### DIFF
--- a/scoutapp/index.html
+++ b/scoutapp/index.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
+  <title>ScoutLink Football Network</title>
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Rajdhani:wght@500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body class="antialiased">
+  <div id="app" class="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+    <header class="relative overflow-hidden">
+      <div class="pointer-events-none" aria-hidden="true">
+        <div class="absolute -top-32 -left-32 h-[420px] w-[420px] rounded-full bg-emerald-500/40 blur-3xl"></div>
+        <div class="absolute top-16 right-0 h-[360px] w-[360px] rounded-full bg-sky-500/25 blur-3xl"></div>
+        <div class="absolute bottom-[-120px] left-1/2 h-[460px] w-[460px] -translate-x-1/2 rounded-full bg-emerald-400/20 blur-3xl"></div>
+      </div>
+      <div class="relative">
+        <nav class="mx-auto flex max-w-7xl items-center justify-between px-6 py-6 text-xs uppercase tracking-[0.3em] text-slate-400">
+          <span class="text-emerald-200">ScoutLink</span>
+          <div class="flex items-center gap-5">
+            <span>Beta build</span>
+            <span>v0.1.0</span>
+          </div>
+        </nav>
+        <div class="mx-auto max-w-7xl px-6 pb-16">
+          <div class="grid items-center gap-12 lg:grid-cols-[1.45fr_1fr]">
+            <div class="space-y-10">
+              <p class="text-xs font-semibold uppercase tracking-[0.6em] text-emerald-300">Football talent network</p>
+              <h1 class="text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-6xl">Connect scouts &amp; players in one electric locker room.</h1>
+              <p id="hero-subtitle" class="max-w-2xl text-lg text-slate-300">Discover rising stars, manage relationships, and keep your shortlists ready for the next transfer window.</p>
+              <div class="flex flex-wrap gap-3">
+                <button class="role-button" data-role="scout" data-role-toggle>I'm scouting talent</button>
+                <button class="role-button role-button--ghost" data-role="player" data-role-toggle>I'm showcasing my game</button>
+              </div>
+              <div class="grid gap-4 border-t border-emerald-500/25 pt-6 sm:grid-cols-2 lg:grid-cols-3">
+                <div class="stat-block">
+                  <p class="stat-label">Verified prospects</p>
+                  <p class="stat-value">126</p>
+                  <p class="stat-sub">Updated daily</p>
+                </div>
+                <div class="stat-block">
+                  <p class="stat-label">Clubs on platform</p>
+                  <p class="stat-value">48</p>
+                  <p class="stat-sub">Across 6 leagues</p>
+                </div>
+                <div class="stat-block">
+                  <p class="stat-label">Highlight minutes streamed</p>
+                  <p class="stat-value">2.4k</p>
+                  <p class="stat-sub">Last 30 days</p>
+                </div>
+              </div>
+            </div>
+            <div class="glass-board space-y-5">
+              <div>
+                <h3 class="text-xs uppercase tracking-[0.5em] text-emerald-200">Match center</h3>
+                <p class="mt-2 text-sm text-slate-300">Keep tabs on combines, showcases, and club needs.</p>
+              </div>
+              <div class="grid gap-4">
+                <div class="match-card">
+                  <p class="match-card__label">Next showcase</p>
+                  <p class="match-card__title">Texas Elite Combine &mdash; Jun 14</p>
+                  <p class="match-card__meta">32 players &middot; 18 scouts confirmed</p>
+                </div>
+                <div class="match-card">
+                  <p class="match-card__label">Transfer window focus</p>
+                  <p class="match-card__title">MLS U22 Initiative Targets</p>
+                  <p class="match-card__meta">8 open roster spots &middot; 3 strikers prioritized</p>
+                </div>
+                <div class="grid gap-3 rounded-3xl border border-emerald-500/25 bg-emerald-500/10 p-5 text-slate-100 shadow-[0_22px_60px_rgba(16,185,129,0.25)]">
+                  <p class="text-xs uppercase tracking-[0.4em] text-emerald-100">Signal strength</p>
+                  <p class="text-2xl font-semibold">Live interest alerts engaged</p>
+                  <p class="text-xs text-emerald-100/80">Get notified when scouts follow, shortlist, or request contact details.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="relative z-10 mx-auto flex w-full max-w-7xl flex-col gap-16 px-6 pb-24">
+      <section id="account-center" class="relative">
+        <div class="glass-card grid gap-10 p-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
+          <div>
+            <div class="flex flex-wrap items-center gap-4">
+              <span id="account-role-chip" class="role-chip">Scout workspace</span>
+              <span class="inline-flex items-center gap-2 text-xs uppercase tracking-[0.35em] text-slate-400">
+                <span id="account-status-dot" class="block h-2.5 w-2.5 rounded-full bg-emerald-400"></span>
+                <span id="account-status">Active</span>
+              </span>
+            </div>
+            <h2 class="mt-6 text-3xl font-semibold text-white">Account control center</h2>
+            <p id="account-summary" class="mt-3 max-w-2xl text-sm text-slate-300">Manage your plan, access, and communication limits in one place. Downgrade when a recruiting cycle slows down, then reactivate instantly before the next window opens.</p>
+            <div class="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              <div class="mini-panel">
+                <p class="mini-panel__label">Current tier</p>
+                <p id="account-tier" class="mini-panel__value">Elite</p>
+              </div>
+              <div class="mini-panel">
+                <p class="mini-panel__label">Saved prospects</p>
+                <p id="account-saved-count" class="mini-panel__value">0</p>
+                <p class="mini-panel__hint">Synced across your staff</p>
+              </div>
+              <div class="mini-panel">
+                <p class="mini-panel__label">Prospect capacity</p>
+                <p id="account-capacity" class="mini-panel__value">Unlimited</p>
+                <p class="mini-panel__hint">Based on active tier</p>
+              </div>
+            </div>
+            <div class="mt-6 flex flex-wrap gap-3">
+              <button id="degrade-account" class="btn-primary">Downgrade to Competitive</button>
+              <button id="restore-account" class="btn-outline hidden">Reactivate Elite tier</button>
+            </div>
+            <p id="account-impact" class="mt-4 text-xs uppercase tracking-[0.35em] text-emerald-200">Full networking privileges engaged</p>
+          </div>
+          <div class="flex flex-col gap-6">
+            <div class="glass-subcard">
+              <h3 class="text-xs uppercase tracking-[0.45em] text-slate-400">Account timeline</h3>
+              <ul id="degrade-history" class="mt-4 space-y-3 text-sm text-slate-300">
+                <li class="text-slate-500">No changes recorded yet — you're running the Elite tier.</li>
+              </ul>
+            </div>
+            <div class="glass-subcard">
+              <h3 class="text-xs uppercase tracking-[0.45em] text-slate-400">Workspace toggle</h3>
+              <div class="mt-4 flex flex-wrap gap-3">
+                <button class="role-switch" data-role="scout" data-role-toggle>Scout mode</button>
+                <button class="role-switch role-switch--ghost" data-role="player" data-role-toggle>Player mode</button>
+              </div>
+              <p class="mt-3 text-xs text-slate-400">Switch roles to tailor messaging, hero copy, and metrics across the experience.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="network" class="relative">
+        <div class="flex flex-wrap items-end justify-between gap-6">
+          <div class="max-w-3xl space-y-3">
+            <p class="text-xs font-semibold uppercase tracking-[0.55em] text-emerald-300">Player discovery lab</p>
+            <h2 class="text-3xl font-semibold text-white">Verified soccer profiles with highlight reels and advanced metrics.</h2>
+            <p class="text-sm text-slate-300">Filter, review, and track prospects. Save them to your notebook, jot quick notes, and deliver messages without leaving the workspace.</p>
+          </div>
+          <div class="rounded-3xl border border-emerald-500/25 bg-emerald-500/10 px-6 py-4 text-sm text-emerald-100 shadow-[0_15px_45px_rgba(16,185,129,0.2)]">
+            <p class="uppercase tracking-[0.4em]">Live feed</p>
+            <p class="mt-1 text-xs text-emerald-100/80">4 new clips added in the last 24 hours</p>
+          </div>
+        </div>
+
+        <div class="mt-10 grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1.7fr)_minmax(0,1.1fr)]">
+          <aside class="glass-card p-6">
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <h3 class="text-lg font-semibold text-white">Prospect board</h3>
+                <p class="text-sm text-slate-400">Tap a profile to load the full report.</p>
+              </div>
+              <span class="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs uppercase tracking-[0.35em] text-emerald-100">Live</span>
+            </div>
+            <div class="mt-6 grid gap-4 text-xs uppercase tracking-[0.4em] text-slate-400">
+              <label class="filter-label">Position
+                <select id="filter-position" class="filter-input mt-2">
+                  <option value="all">All positions</option>
+                  <option value="forward">Forwards</option>
+                  <option value="midfield">Midfielders</option>
+                  <option value="defense">Defenders</option>
+                  <option value="goalkeeper">Goalkeepers</option>
+                </select>
+              </label>
+              <label class="filter-label">Preferred foot
+                <select id="filter-foot" class="filter-input mt-2">
+                  <option value="all">Any</option>
+                  <option value="right">Right</option>
+                  <option value="left">Left</option>
+                </select>
+              </label>
+              <label class="filter-label">Search
+                <input id="filter-search" type="search" placeholder="Name, club, style..." class="filter-input mt-2">
+              </label>
+            </div>
+            <div id="player-list" class="mt-6 flex flex-col gap-4"></div>
+          </aside>
+
+          <article id="player-detail" class="glass-card p-6">
+            <header class="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <p id="detail-position" class="text-xs uppercase tracking-[0.45em] text-emerald-200">Select a profile</p>
+                <h3 id="detail-name" class="mt-2 text-3xl font-semibold text-white">No player selected</h3>
+                <p id="detail-location" class="mt-2 text-sm text-slate-400">Choose a player from the prospect board to load their scouting report.</p>
+              </div>
+              <div class="text-right">
+                <p id="detail-availability" class="text-xs uppercase tracking-[0.45em] text-emerald-200"></p>
+                <p id="detail-updated" class="mt-2 text-xs text-slate-500"></p>
+              </div>
+            </header>
+
+            <div id="highlight-container" class="highlight-shell mt-6">
+              <div class="flex flex-col items-center justify-center text-center text-sm text-slate-400">
+                <span class="text-lg font-semibold text-slate-300">Highlight hub</span>
+                <span class="mt-1 text-xs uppercase tracking-[0.4em] text-slate-500">Select a player to load match footage</span>
+              </div>
+            </div>
+
+            <div id="detail-stats" class="detail-stats mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-3"></div>
+            <div id="player-tags" class="mt-6 flex flex-wrap gap-2"></div>
+
+            <section class="mt-6 space-y-3">
+              <h4 class="section-title">Scouting report</h4>
+              <p id="detail-bio" class="text-sm leading-relaxed text-slate-300"></p>
+              <ul id="detail-highlight-notes" class="space-y-2 text-sm text-slate-300"></ul>
+            </section>
+
+            <section class="mt-6 grid gap-5 lg:grid-cols-2">
+              <div>
+                <h4 class="section-title">Key metrics</h4>
+                <dl id="detail-metrics" class="grid gap-3 text-sm text-slate-200"></dl>
+              </div>
+              <div>
+                <h4 class="section-title">Representation</h4>
+                <ul id="detail-contact" class="space-y-2 text-sm text-slate-300"></ul>
+              </div>
+            </section>
+
+            <section class="mt-6">
+              <h4 class="section-title">Recent honors</h4>
+              <ul id="detail-honors" class="mt-3 grid gap-2 text-sm text-emerald-200 sm:grid-cols-2"></ul>
+            </section>
+
+            <section class="mt-6">
+              <h4 class="section-title">Upcoming fixtures</h4>
+              <ul id="detail-fixtures" class="mt-3 grid gap-3 text-sm text-slate-300 sm:grid-cols-2"></ul>
+            </section>
+
+            <div class="mt-8 flex flex-wrap gap-3">
+              <button id="save-prospect" class="btn-primary" disabled>Save to notebook</button>
+              <button id="open-message" class="btn-outline" disabled>Compose message</button>
+            </div>
+          </article>
+
+          <aside class="flex flex-col gap-6">
+            <section class="glass-card p-6">
+              <div class="flex items-start justify-between gap-3">
+                <div>
+                  <h3 class="text-lg font-semibold text-white">Scout notebook</h3>
+                  <p class="text-sm text-slate-400">Bookmark prospects and leave context for your staff.</p>
+                </div>
+                <span id="saved-count" class="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs uppercase tracking-[0.35em] text-emerald-100">0 saved</span>
+              </div>
+              <div id="saved-empty" class="mt-6 rounded-2xl border border-dashed border-emerald-500/30 bg-slate-950/60 p-6 text-center text-sm text-slate-400">
+                Save a player to build your recruitment list.
+              </div>
+              <div id="saved-prospects" class="mt-6 flex flex-col gap-4"></div>
+            </section>
+
+            <section class="glass-card p-6">
+              <h3 class="text-lg font-semibold text-white">Direct outreach</h3>
+              <p id="messaging-availability" class="mt-2 text-xs uppercase tracking-[0.35em] text-emerald-200">Messaging open to the entire player pool.</p>
+              <form id="message-form" class="mt-6 space-y-4">
+                <label class="filter-label">Player
+                  <select id="message-player" class="filter-input mt-2"></select>
+                </label>
+                <label class="filter-label">Channel
+                  <select id="message-channel" class="filter-input mt-2">
+                    <option value="Direct Message">Direct Message</option>
+                    <option value="Email Intro">Email Intro</option>
+                    <option value="WhatsApp Call">WhatsApp Call</option>
+                  </select>
+                </label>
+                <label class="filter-label">Subject
+                  <input id="message-subject" type="text" placeholder="Intro: Summer trials" class="filter-input mt-2">
+                </label>
+                <label class="filter-label">Message
+                  <textarea id="message-body" rows="4" placeholder="Share who you are, your interest, and next steps." class="filter-input mt-2 h-32 resize-none"></textarea>
+                </label>
+                <button id="submit-message" type="submit" class="btn-primary w-full">Send scouting message</button>
+                <p id="message-feedback" class="hidden text-xs text-emerald-200" role="status">Message staged for delivery.</p>
+              </form>
+              <div class="mt-6">
+                <h4 class="section-title">Recent outreach</h4>
+                <ul id="message-history" class="mt-3 space-y-3 text-sm text-slate-300">
+                  <li class="text-slate-500">No messages yet. Reach out to a prospect to populate this feed.</li>
+                </ul>
+              </div>
+            </section>
+          </aside>
+        </div>
+      </section>
+    </main>
+
+    <footer class="relative border-t border-slate-800/60 bg-slate-950/80 py-10">
+      <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4 px-6 text-xs uppercase tracking-[0.35em] text-slate-500">
+        <span>&copy; 2024 ScoutLink Labs</span>
+        <span>Designed for the beautiful game</span>
+        <span>v0.1.0 &middot; Beta</span>
+      </div>
+    </footer>
+  </div>
+
+  <div id="toast-shell" class="toast-shell hidden" aria-live="polite" aria-atomic="true">
+    <div id="toast-content" class="toast-content">Status message</div>
+  </div>
+
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/scoutapp/main.js
+++ b/scoutapp/main.js
@@ -1,0 +1,1182 @@
+const accountStages = [
+  {
+    id: 'elite',
+    title: 'Elite',
+    status: 'Active',
+    summary: 'Full networking privileges with unlimited messaging and scouting exports.',
+    messaging: 'Messaging open to the entire player pool.',
+    degradeLabel: 'Downgrade to Competitive',
+    savedLimit: Infinity,
+    requireSavedForMessaging: false,
+    messagingDisabled: false
+  },
+  {
+    id: 'competitive',
+    title: 'Competitive',
+    status: 'Active',
+    summary: 'Keep your staff aligned with light limits and outreach analytics.',
+    messaging: 'Messaging open with weekly outreach reminders.',
+    degradeLabel: 'Downgrade to Basic',
+    savedLimit: 40,
+    requireSavedForMessaging: false,
+    messagingDisabled: false
+  },
+  {
+    id: 'basic',
+    title: 'Basic',
+    status: 'Limited',
+    summary: 'Profiles stay visible while messaging is limited to saved prospects.',
+    messaging: 'Messaging limited to saved prospects. Save a player to start conversations.',
+    degradeLabel: 'Deactivate to Dormant',
+    savedLimit: 12,
+    requireSavedForMessaging: true,
+    messagingDisabled: false
+  },
+  {
+    id: 'dormant',
+    title: 'Dormant',
+    status: 'Inactive',
+    summary: 'Account hidden from discovery until reactivated. Messaging is paused.',
+    messaging: 'Messaging disabled while dormant. Reactivate to reopen conversations.',
+    degradeLabel: null,
+    savedLimit: 12,
+    requireSavedForMessaging: true,
+    messagingDisabled: true
+  }
+];
+
+const roleCopy = {
+  scout: {
+    heroSubtitle: 'Discover rising stars, manage relationships, and keep your shortlists ready for the next transfer window.',
+    accountSummary: 'Manage your plan, access, and communication limits in one place. Downgrade when a recruiting cycle slows down, then reactivate instantly before the next window opens.',
+    roleChip: 'Scout workspace',
+    toast: 'Scout workspace engaged.'
+  },
+  player: {
+    heroSubtitle: 'Showcase your story with verified highlights, advanced metrics, and direct access to the scouts looking for your profile.',
+    accountSummary: 'Control how scouts experience your profile. Pause outreach during recovery spells, then reactivate before trials or showcases.',
+    roleChip: 'Player workspace',
+    toast: 'Player workspace engaged.'
+  }
+};
+
+const rawPlayers = [
+  {
+    id: 'liam-carter',
+    name: 'Liam Carter',
+    position: 'Striker',
+    positionGroup: 'forward',
+    club: 'River City FC',
+    league: 'USL Championship',
+    location: 'Austin, USA',
+    age: 22,
+    height: "6'1\"",
+    footedness: 'Right',
+    availability: 'Open to MLS summer window transfer',
+    lastUpdated: 'May 28, 2024',
+    highlightUrl: 'https://www.youtube.com/embed/IyR_uYsRdPs?rel=0&modestbranding=1',
+    keyStats: [
+      { label: 'Goals', value: '18' },
+      { label: 'Assists', value: '9' },
+      { label: 'Rating', value: '7.84' }
+    ],
+    stats: [
+      { label: 'Goals', value: '18', context: 'USL Championship — 2023/24' },
+      { label: 'Assists', value: '9', context: 'USL Championship — 2023/24' },
+      { label: 'Shots on target', value: '64%', context: 'Career high' },
+      { label: 'xG per 90', value: '0.74', context: 'Top 5 in league' },
+      { label: 'Pressures won', value: '47', context: 'Final third' },
+      { label: 'Sprint speed', value: '34.1 km/h', context: 'GPS tracker' }
+    ],
+    tags: ['Pressing forward', 'MLS ready', 'Leadership'],
+    bio: 'High-tempo striker who thrives pressing from the front. Attacks inside channels, links quickly, and finishes confidently with either foot.',
+    highlightNotes: [
+      'Hat trick vs. Phoenix Rising (Apr 2024)',
+      'Led team in expected goals and sprints per 90',
+      'Captain for River City FC with 88% availability'
+    ],
+    metrics: [
+      { label: 'Top speed', value: '34.1 km/h' },
+      { label: 'Sprints per 90', value: '23' },
+      { label: 'Conversion rate', value: '27%' },
+      { label: 'Weak foot rating', value: '4 / 5' }
+    ],
+    contact: [
+      { type: 'Agent', value: 'Sarah Coleman — Next Level Sports' },
+      { type: 'Email', value: 'scarter@nextlevelsports.com' },
+      { type: 'Phone', value: '+1 (555) 234-8876' }
+    ],
+    achievements: [
+      '2023 USL Young Player of the Year',
+      'Called into U.S. U-23 national team camp (Jan 2024)'
+    ],
+    fixtures: [
+      { opponent: 'Sacramento Republic', date: 'Jun 18', competition: 'USL Championship' },
+      { opponent: 'El Paso Locomotive', date: 'Jun 24', competition: 'USL Championship' }
+    ],
+    searchKeywords: ['liam carter', 'river city fc', 'forward', 'striker', 'pressing', 'mls', 'usl championship', 'texas']
+  },
+  {
+    id: 'mateo-ruiz',
+    name: 'Mateo Ruiz',
+    position: 'Central Midfielder',
+    positionGroup: 'midfield',
+    club: 'CF Monterrey U-23',
+    league: 'Liga MX U-23',
+    location: 'Monterrey, Mexico',
+    age: 20,
+    height: "5'10\"",
+    footedness: 'Left',
+    availability: 'Loan-friendly — open to USL & MLS NEXT Pro opportunities',
+    lastUpdated: 'May 26, 2024',
+    highlightUrl: 'https://www.youtube.com/embed/IyR_uYsRdPs?rel=0&modestbranding=1',
+    keyStats: [
+      { label: 'Assists', value: '12' },
+      { label: 'xA / 90', value: '0.32' },
+      { label: 'Prog. passes', value: '7.8' }
+    ],
+    stats: [
+      { label: 'Chances created', value: '54', context: 'Liga MX U-23 — 2023/24' },
+      { label: 'Progressive passes', value: '7.8', context: 'Per 90 minutes' },
+      { label: 'Assists', value: '12', context: 'All competitions' },
+      { label: 'Pass completion', value: '89%', context: 'Central third' },
+      { label: 'Ball recoveries', value: '8.6', context: 'Per 90 minutes' },
+      { label: 'Expected assists', value: '0.32', context: 'Per 90 minutes' }
+    ],
+    tags: ['Tempo setter', 'Left-footed', 'Press resistant'],
+    bio: 'Two-way midfielder comfortable breaking lines off the dribble or with disguised passing angles. Calm under pressure and vocal organizing teammates.',
+    highlightNotes: [
+      'Nine progressive passes in U-23 semifinal win',
+      '90th percentile for deep completions in Liga MX U-23',
+      'Captains the U-23 side during transition phases'
+    ],
+    metrics: [
+      { label: 'Pass completion', value: '91% short / 84% long' },
+      { label: 'Progressive carries', value: '5.2 per 90' },
+      { label: 'Press resistance', value: '92nd percentile' },
+      { label: 'Defensive duels won', value: '62%' }
+    ],
+    contact: [
+      { type: 'Club liaison', value: 'Ana Torres — CF Monterrey Development' },
+      { type: 'Email', value: 'atorres@cfm.mx' },
+      { type: 'WhatsApp', value: '+52 55 1234 7788' }
+    ],
+    achievements: [
+      '2024 Liga MX U-23 Midfielder of the Tournament',
+      'Called into Mexico U-21 national team (Mar 2024)'
+    ],
+    fixtures: [
+      { opponent: 'Club León U-23', date: 'Jun 20', competition: 'Liga MX U-23 Playoffs' },
+      { opponent: 'Atlas U-23', date: 'Jun 27', competition: 'Liga MX U-23 Playoffs' }
+    ],
+    searchKeywords: ['mateo ruiz', 'cf monterrey', 'midfielder', 'left foot', 'liga mx', 'playmaker', 'mexico']
+  },
+  {
+    id: 'dante-wallace',
+    name: 'Dante Wallace',
+    position: 'Center Back',
+    positionGroup: 'defense',
+    club: 'Queen City Athletic',
+    league: 'USL League One',
+    location: 'Charlotte, USA',
+    age: 24,
+    height: "6'3\"",
+    footedness: 'Right',
+    availability: 'Monitoring Championship & MLS NEXT Pro interest',
+    lastUpdated: 'May 20, 2024',
+    highlightUrl: 'https://www.youtube.com/embed/IyR_uYsRdPs?rel=0&modestbranding=1',
+    keyStats: [
+      { label: 'Duels won', value: '74%' },
+      { label: 'Aerials', value: '72%' },
+      { label: 'Rating', value: '7.58' }
+    ],
+    stats: [
+      { label: 'Duels won', value: '74%', context: 'Defensive duels 2023/24' },
+      { label: 'Aerial success', value: '72%', context: 'Season average' },
+      { label: 'Long pass accuracy', value: '68%', context: 'Over 30 metres' },
+      { label: 'Blocks', value: '1.9', context: 'Per 90 minutes' },
+      { label: 'Interceptions', value: '7.2', context: 'Per 90 minutes' },
+      { label: 'Line-breaking passes', value: '8', context: 'Per match vs high press' }
+    ],
+    tags: ['Ball-playing CB', 'Set piece threat', 'Leadership'],
+    bio: 'Commanding center back who breaks lines with his passing. Vocal organizer with excellent timing and range in aerial duels.',
+    highlightNotes: [
+      'Match-winning header in League One semifinal (Oct 2023)',
+      'Captained Queen City Athletic to league-best defense',
+      'Consistently among top 5 defenders in acceleration metrics'
+    ],
+    metrics: [
+      { label: 'Clearances', value: '6.8 per 90' },
+      { label: 'Progressive passes', value: '7.1 per 90' },
+      { label: 'Top vertical leap', value: '76 cm' },
+      { label: 'Left-foot distribution', value: '82% accuracy' }
+    ],
+    contact: [
+      { type: 'Agency', value: 'Jordan Blake — Backline Sports Group' },
+      { type: 'Email', value: 'jblake@backlinegroup.com' },
+      { type: 'Phone', value: '+1 (704) 555-0198' }
+    ],
+    achievements: [
+      '2023 USL League One Best XI',
+      'Led defense with league-low xGA (2023)'
+    ],
+    fixtures: [
+      { opponent: 'Greenville Triumph', date: 'Jun 22', competition: 'USL League One' },
+      { opponent: 'Richmond Kickers', date: 'Jun 29', competition: 'USL League One' }
+    ],
+    searchKeywords: ['dante wallace', 'center back', 'queen city athletic', 'defender', 'usl league one', 'ball playing']
+  },
+  {
+    id: 'koji-tanaka',
+    name: 'Koji Tanaka',
+    position: 'Goalkeeper',
+    positionGroup: 'goalkeeper',
+    club: 'Yokohama Metro FC',
+    league: 'J2 League',
+    location: 'Yokohama, Japan',
+    age: 25,
+    height: "6'2\"",
+    footedness: 'Left',
+    availability: 'Monitoring interest for winter transfer window',
+    lastUpdated: 'May 18, 2024',
+    highlightUrl: 'https://www.youtube.com/embed/IyR_uYsRdPs?rel=0&modestbranding=1',
+    keyStats: [
+      { label: 'Clean sheets', value: '11' },
+      { label: 'Save %', value: '78%' },
+      { label: 'Launch acc.', value: '58%' }
+    ],
+    stats: [
+      { label: 'Clean sheets', value: '11', context: 'J2 League 2023/24' },
+      { label: 'Save percentage', value: '78%', context: 'All competitions' },
+      { label: 'Sweeper actions', value: '2.4', context: 'Per 90 minutes' },
+      { label: 'Pass completion', value: '86%', context: 'Short distribution' },
+      { label: 'Launch accuracy', value: '58%', context: 'Long distribution' },
+      { label: 'Crosses claimed', value: '1.8', context: 'Per 90 minutes' }
+    ],
+    tags: ['Sweeper keeper', 'Left-footed', 'Calm under pressure'],
+    bio: 'Modern goalkeeper comfortable initiating build-up with either foot. Commands his box and scans early to trigger transition passes.',
+    highlightNotes: [
+      'Player of the Match vs Tokyo Verdy (12 saves)',
+      'Led Yokohama Metro to best defensive record since 2019',
+      'Completed 87% of passes under pressure last month'
+    ],
+    metrics: [
+      { label: 'Penalty saves', value: '3 / 5 this season' },
+      { label: 'Avg. starting position', value: '17.6 m' },
+      { label: 'Launch accuracy', value: '58%' },
+      { label: 'Passes per game', value: '42' }
+    ],
+    contact: [
+      { type: 'Club contact', value: 'Hiroshi Sato — Yokohama Metro FC' },
+      { type: 'Email', value: 'hsato@yokometro.jp' },
+      { type: 'Phone', value: '+81 45-555-0199' }
+    ],
+    achievements: [
+      "2023 Emperor's Cup semifinal standout (10 saves)",
+      'Named to J2 League Team of the Month (Mar 2024)'
+    ],
+    fixtures: [
+      { opponent: 'Vegalta Sendai', date: 'Jun 21', competition: 'J2 League' },
+      { opponent: 'Ventforet Kofu', date: 'Jun 28', competition: 'J2 League' }
+    ],
+    searchKeywords: ['koji tanaka', 'goalkeeper', 'yokohama metro', 'japan', 'sweeper keeper', 'left foot']
+  }
+];
+
+const players = rawPlayers.map(player => {
+  const keywordString = [
+    player.name,
+    player.club,
+    player.league,
+    player.position,
+    player.location,
+    player.availability,
+    player.footedness,
+    ...(player.tags || []),
+    ...(player.searchKeywords || [])
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  return {
+    ...player,
+    searchIndex: keywordString
+  };
+});
+
+const playerMap = new Map(players.map(player => [player.id, player]));
+
+const state = {
+  role: 'scout',
+  stageIndex: 0,
+  currentPlayerId: players[0] ? players[0].id : null,
+  filters: {
+    position: 'all',
+    foot: 'all',
+    search: ''
+  },
+  savedProspects: new Map(),
+  messages: [],
+  degradeHistory: []
+};
+
+const elements = {};
+let toastTimeoutId = null;
+let searchDebounceId = null;
+
+const formatDate = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+const formatDateTime = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+
+function cacheElements() {
+  elements.heroSubtitle = document.getElementById('hero-subtitle');
+  elements.accountSummary = document.getElementById('account-summary');
+  elements.accountRoleChip = document.getElementById('account-role-chip');
+  elements.accountStatus = document.getElementById('account-status');
+  elements.accountStatusDot = document.getElementById('account-status-dot');
+  elements.accountTier = document.getElementById('account-tier');
+  elements.accountImpact = document.getElementById('account-impact');
+  elements.accountSavedCount = document.getElementById('account-saved-count');
+  elements.accountCapacity = document.getElementById('account-capacity');
+  elements.degradeButton = document.getElementById('degrade-account');
+  elements.restoreButton = document.getElementById('restore-account');
+  elements.degradeHistory = document.getElementById('degrade-history');
+  elements.playerList = document.getElementById('player-list');
+  elements.filterPosition = document.getElementById('filter-position');
+  elements.filterFoot = document.getElementById('filter-foot');
+  elements.filterSearch = document.getElementById('filter-search');
+  elements.detailPosition = document.getElementById('detail-position');
+  elements.detailName = document.getElementById('detail-name');
+  elements.detailLocation = document.getElementById('detail-location');
+  elements.detailAvailability = document.getElementById('detail-availability');
+  elements.detailUpdated = document.getElementById('detail-updated');
+  elements.highlightContainer = document.getElementById('highlight-container');
+  elements.detailStats = document.getElementById('detail-stats');
+  elements.playerTags = document.getElementById('player-tags');
+  elements.detailBio = document.getElementById('detail-bio');
+  elements.detailHighlightNotes = document.getElementById('detail-highlight-notes');
+  elements.detailMetrics = document.getElementById('detail-metrics');
+  elements.detailContact = document.getElementById('detail-contact');
+  elements.detailHonors = document.getElementById('detail-honors');
+  elements.detailFixtures = document.getElementById('detail-fixtures');
+  elements.saveProspect = document.getElementById('save-prospect');
+  elements.openMessage = document.getElementById('open-message');
+  elements.savedContainer = document.getElementById('saved-prospects');
+  elements.savedEmpty = document.getElementById('saved-empty');
+  elements.savedCountBadge = document.getElementById('saved-count');
+  elements.messageForm = document.getElementById('message-form');
+  elements.messagePlayer = document.getElementById('message-player');
+  elements.messageChannel = document.getElementById('message-channel');
+  elements.messageSubject = document.getElementById('message-subject');
+  elements.messageBody = document.getElementById('message-body');
+  elements.submitMessage = document.getElementById('submit-message');
+  elements.messageFeedback = document.getElementById('message-feedback');
+  elements.messageHistory = document.getElementById('message-history');
+  elements.messagingAvailability = document.getElementById('messaging-availability');
+  elements.toastShell = document.getElementById('toast-shell');
+  elements.toastContent = document.getElementById('toast-content');
+}
+
+function attachEventListeners() {
+  document.querySelectorAll('[data-role-toggle]').forEach(button => {
+    button.addEventListener('click', () => {
+      const role = button.dataset.role;
+      if (role) {
+        setRole(role);
+      }
+    });
+  });
+
+  if (elements.degradeButton) {
+    elements.degradeButton.addEventListener('click', degradeAccount);
+  }
+  if (elements.restoreButton) {
+    elements.restoreButton.addEventListener('click', restoreAccount);
+  }
+
+  if (elements.filterPosition) {
+    elements.filterPosition.addEventListener('change', event => {
+      state.filters.position = event.target.value || 'all';
+      applyFilters();
+    });
+  }
+
+  if (elements.filterFoot) {
+    elements.filterFoot.addEventListener('change', event => {
+      state.filters.foot = event.target.value || 'all';
+      applyFilters();
+    });
+  }
+
+  if (elements.filterSearch) {
+    elements.filterSearch.addEventListener('input', event => {
+      const value = event.target.value || '';
+      clearTimeout(searchDebounceId);
+      searchDebounceId = setTimeout(() => {
+        state.filters.search = value;
+        applyFilters();
+      }, 160);
+    });
+  }
+
+  if (elements.playerList) {
+    elements.playerList.addEventListener('click', event => {
+      const card = event.target.closest('[data-player-id]');
+      if (!card) return;
+      const playerId = card.dataset.playerId;
+      if (playerId) {
+        showPlayerDetail(playerId);
+      }
+    });
+  }
+
+  if (elements.saveProspect) {
+    elements.saveProspect.addEventListener('click', () => {
+      if (state.currentPlayerId) {
+        handleSaveProspect(state.currentPlayerId);
+      }
+    });
+  }
+
+  if (elements.openMessage) {
+    elements.openMessage.addEventListener('click', () => {
+      if (state.currentPlayerId) {
+        handleOpenMessage(state.currentPlayerId);
+      }
+    });
+  }
+
+  if (elements.savedContainer) {
+    elements.savedContainer.addEventListener('click', event => {
+      const removeButton = event.target.closest('[data-remove-prospect]');
+      const openButton = event.target.closest('[data-open-prospect]');
+      const card = event.target.closest('[data-player-id]');
+      if (!card) return;
+      const playerId = card.dataset.playerId;
+      if (removeButton && playerId) {
+        removeProspect(playerId);
+      } else if (openButton && playerId) {
+        showPlayerDetail(playerId);
+        const detailSection = document.getElementById('player-detail');
+        if (detailSection && detailSection.scrollIntoView) {
+          detailSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      }
+    });
+
+    elements.savedContainer.addEventListener('change', event => {
+      const noteField = event.target.closest('textarea[data-prospect-note]');
+      if (!noteField) return;
+      const card = noteField.closest('[data-player-id]');
+      if (!card) return;
+      const playerId = card.dataset.playerId;
+      const entry = state.savedProspects.get(playerId);
+      if (!entry) return;
+      entry.note = noteField.value;
+      entry.updatedAt = new Date();
+      showToast('Notebook note updated.', 'success');
+    });
+  }
+
+  if (elements.messageForm) {
+    elements.messageForm.addEventListener('submit', handleMessageSubmit);
+  }
+}
+
+function setRole(role) {
+  if (!roleCopy[role]) return;
+  if (state.role === role) {
+    updateRoleUI();
+    return;
+  }
+  state.role = role;
+  updateRoleUI();
+  showToast(roleCopy[role].toast, 'info');
+}
+
+function updateRoleUI() {
+  const copy = roleCopy[state.role];
+  if (!copy) return;
+  if (elements.heroSubtitle) {
+    elements.heroSubtitle.textContent = copy.heroSubtitle;
+  }
+  if (elements.accountSummary) {
+    elements.accountSummary.textContent = copy.accountSummary;
+  }
+  if (elements.accountRoleChip) {
+    elements.accountRoleChip.textContent = copy.roleChip;
+  }
+  document.querySelectorAll('[data-role-toggle]').forEach(button => {
+    const isActive = button.dataset.role === state.role;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', String(isActive));
+  });
+}
+
+function degradeAccount() {
+  if (state.stageIndex >= accountStages.length - 1) {
+    showToast('Account already dormant. Reactivate to unlock features.', 'warning');
+    return;
+  }
+  state.stageIndex += 1;
+  state.degradeHistory.push({
+    type: 'downgrade',
+    stageIndex: state.stageIndex,
+    timestamp: new Date()
+  });
+  updateAccountPanel();
+  updateMessagingAccess();
+  const stage = accountStages[state.stageIndex];
+  showToast(`Account downgraded to ${stage.title}.`, 'warning');
+}
+
+function restoreAccount() {
+  if (state.stageIndex === 0) {
+    showToast('Elite tier already active.', 'info');
+    return;
+  }
+  state.stageIndex = 0;
+  state.degradeHistory.push({
+    type: 'reactivate',
+    stageIndex: state.stageIndex,
+    timestamp: new Date()
+  });
+  updateAccountPanel();
+  updateMessagingAccess();
+  showToast('Elite tier reactivated. Full access restored.', 'success');
+}
+
+function updateAccountPanel() {
+  const stage = accountStages[state.stageIndex];
+  if (!stage) return;
+
+  if (elements.accountTier) {
+    elements.accountTier.textContent = stage.title;
+  }
+  if (elements.accountImpact) {
+    elements.accountImpact.textContent = stage.summary;
+  }
+  if (elements.accountStatus) {
+    elements.accountStatus.textContent = stage.status;
+  }
+  if (elements.accountStatusDot) {
+    const color = stage.status === 'Active' ? '#22c55e' : stage.status === 'Limited' ? '#fbbf24' : '#f87171';
+    elements.accountStatusDot.style.backgroundColor = color;
+  }
+  if (elements.degradeButton) {
+    elements.degradeButton.textContent = stage.degradeLabel || 'Dormant tier active';
+    elements.degradeButton.disabled = !stage.degradeLabel;
+  }
+  if (elements.restoreButton) {
+    elements.restoreButton.classList.toggle('hidden', state.stageIndex === 0);
+  }
+  renderDegradeHistory();
+  renderSavedProspects();
+}
+
+function renderDegradeHistory() {
+  if (!elements.degradeHistory) return;
+  if (!state.degradeHistory.length) {
+    elements.degradeHistory.innerHTML = '<li class="text-slate-500">No changes recorded yet — you\'re running the Elite tier.</li>';
+    return;
+  }
+
+  const items = [...state.degradeHistory]
+    .slice()
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .map(entry => {
+      const stage = accountStages[entry.stageIndex];
+      const label = entry.type === 'reactivate'
+        ? 'Reactivated Elite tier'
+        : `Downgraded to ${stage ? stage.title : 'next tier'}`;
+      const stamp = formatDateTime.format(entry.timestamp);
+      return `
+        <li class="rounded-2xl border border-emerald-500/20 bg-slate-950/50 px-4 py-3 text-sm">
+          <p class="font-semibold text-emerald-200">${label}</p>
+          <p class="mt-1 text-xs uppercase tracking-[0.35em] text-slate-500">${stamp}</p>
+        </li>
+      `;
+    })
+    .join('');
+
+  elements.degradeHistory.innerHTML = items;
+}
+
+function applyFilters() {
+  const { position, foot, search } = state.filters;
+  const normalizedSearch = (search || '').trim().toLowerCase();
+
+  const filtered = players.filter(player => {
+    const matchesPosition = position === 'all' || player.positionGroup === position;
+    const matchesFoot = foot === 'all' || player.footedness.toLowerCase() === foot;
+    const matchesSearch = !normalizedSearch || player.searchIndex.includes(normalizedSearch);
+    return matchesPosition && matchesFoot && matchesSearch;
+  });
+
+  renderPlayerGrid(filtered);
+
+  let nextId = state.currentPlayerId;
+  if (!filtered.some(player => player.id === state.currentPlayerId)) {
+    nextId = filtered.length ? filtered[0].id : null;
+  }
+
+  showPlayerDetail(nextId);
+}
+
+function renderPlayerGrid(list) {
+  if (!elements.playerList) return;
+  if (!list.length) {
+    elements.playerList.innerHTML = `
+      <p class="rounded-2xl border border-dashed border-emerald-500/30 bg-slate-950/60 p-6 text-center text-sm text-slate-400">
+        No players match your filters yet. Adjust the filters or clear your search.
+      </p>
+    `;
+    return;
+  }
+
+  const cards = list.map(player => {
+    const isActive = player.id === state.currentPlayerId;
+    const stats = player.keyStats
+      .map(stat => `
+        <div class="player-card__stat">
+          <span class="label">${stat.label}</span>
+          <span class="value">${stat.value}</span>
+        </div>
+      `)
+      .join('');
+
+    return `
+      <button type="button" class="player-card${isActive ? ' active' : ''}" data-player-id="${player.id}">
+        <div class="player-card__header">
+          <div>
+            <p class="player-card__position">${player.position}</p>
+            <p class="player-card__name">${player.name}</p>
+          </div>
+          <p class="player-card__club">${player.club}</p>
+        </div>
+        <div class="player-card__stats">${stats}</div>
+        <p class="player-card__footer">Last updated ${player.lastUpdated}</p>
+      </button>
+    `;
+  }).join('');
+
+  elements.playerList.innerHTML = cards;
+}
+
+function showPlayerDetail(playerId) {
+  state.currentPlayerId = playerId || null;
+  highlightActiveCard();
+  const player = playerId ? playerMap.get(playerId) : null;
+
+  if (!player) {
+    if (elements.detailPosition) elements.detailPosition.textContent = 'Select a profile';
+    if (elements.detailName) elements.detailName.textContent = 'No player selected';
+    if (elements.detailLocation) elements.detailLocation.textContent = 'Choose a player from the prospect board to load their scouting report.';
+    if (elements.detailAvailability) elements.detailAvailability.textContent = '';
+    if (elements.detailUpdated) elements.detailUpdated.textContent = '';
+    if (elements.highlightContainer) {
+      elements.highlightContainer.innerHTML = `
+        <div class="flex flex-col items-center justify-center text-center text-sm text-slate-400">
+          <span class="text-lg font-semibold text-slate-300">Highlight hub</span>
+          <span class="mt-1 text-xs uppercase tracking-[0.4em] text-slate-500">Select a player to load match footage</span>
+        </div>
+      `;
+    }
+    clearDetailSections();
+    updateActionButtons(null);
+    return;
+  }
+
+  if (elements.detailPosition) {
+    elements.detailPosition.textContent = `${player.position} • ${player.club}`;
+  }
+  if (elements.detailName) {
+    elements.detailName.textContent = player.name;
+  }
+  if (elements.detailLocation) {
+    const locationBits = [player.location, `${player.age} yrs`, player.height, `${player.footedness}-footed`].filter(Boolean);
+    elements.detailLocation.textContent = locationBits.join(' • ');
+  }
+  if (elements.detailAvailability) {
+    elements.detailAvailability.textContent = player.availability || '';
+  }
+  if (elements.detailUpdated) {
+    elements.detailUpdated.textContent = player.lastUpdated ? `Updated ${player.lastUpdated}` : '';
+  }
+
+  renderHighlight(player);
+  renderDetailStats(player);
+  renderTags(player);
+  if (elements.detailBio) {
+    elements.detailBio.textContent = player.bio || '';
+  }
+  renderHighlightNotes(player);
+  renderMetrics(player);
+  renderContact(player);
+  renderHonors(player);
+  renderFixtures(player);
+  updateActionButtons(player);
+}
+
+function clearDetailSections() {
+  if (elements.detailStats) elements.detailStats.innerHTML = '';
+  if (elements.playerTags) elements.playerTags.innerHTML = '';
+  if (elements.detailBio) elements.detailBio.textContent = '';
+  if (elements.detailHighlightNotes) elements.detailHighlightNotes.innerHTML = '';
+  if (elements.detailMetrics) elements.detailMetrics.innerHTML = '';
+  if (elements.detailContact) elements.detailContact.innerHTML = '';
+  if (elements.detailHonors) elements.detailHonors.innerHTML = '';
+  if (elements.detailFixtures) elements.detailFixtures.innerHTML = '';
+}
+
+function renderHighlight(player) {
+  if (!elements.highlightContainer) return;
+  if (player.highlightUrl) {
+    elements.highlightContainer.innerHTML = `
+      <iframe
+        src="${player.highlightUrl}"
+        title="${player.name} highlight reel"
+        loading="lazy"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+      ></iframe>
+    `;
+  } else {
+    elements.highlightContainer.innerHTML = `
+      <div class="flex h-full flex-col items-center justify-center gap-2 text-center text-sm text-slate-400">
+        <span class="text-lg font-semibold text-slate-300">No highlight uploaded yet</span>
+        <span class="text-xs uppercase tracking-[0.4em] text-slate-500">Request footage from the player</span>
+      </div>
+    `;
+  }
+}
+
+function renderDetailStats(player) {
+  if (!elements.detailStats) return;
+  if (!player.stats || !player.stats.length) {
+    elements.detailStats.innerHTML = '<p class="text-sm text-slate-400">Stats coming soon.</p>';
+    return;
+  }
+  const stats = player.stats.map(stat => `
+    <div class="stat-card">
+      <p class="stat-label">${stat.label}</p>
+      <p class="stat-number">${stat.value}</p>
+      ${stat.context ? `<p class="stat-context">${stat.context}</p>` : ''}
+    </div>
+  `).join('');
+  elements.detailStats.innerHTML = stats;
+}
+
+function renderTags(player) {
+  if (!elements.playerTags) return;
+  if (!player.tags || !player.tags.length) {
+    elements.playerTags.innerHTML = '';
+    return;
+  }
+  elements.playerTags.innerHTML = player.tags.map(tag => `<span class="tag-chip">${tag}</span>`).join('');
+}
+
+function renderHighlightNotes(player) {
+  if (!elements.detailHighlightNotes) return;
+  if (!player.highlightNotes || !player.highlightNotes.length) {
+    elements.detailHighlightNotes.innerHTML = '';
+    return;
+  }
+  const list = player.highlightNotes.map(note => `<li>• ${note}</li>`).join('');
+  elements.detailHighlightNotes.innerHTML = list;
+}
+
+function renderMetrics(player) {
+  if (!elements.detailMetrics) return;
+  if (!player.metrics || !player.metrics.length) {
+    elements.detailMetrics.innerHTML = '';
+    return;
+  }
+  const metrics = player.metrics.map(metric => `
+    <div class="metric-row">
+      <dt>${metric.label}</dt>
+      <dd>${metric.value}</dd>
+    </div>
+  `).join('');
+  elements.detailMetrics.innerHTML = metrics;
+}
+
+function renderContact(player) {
+  if (!elements.detailContact) return;
+  if (!player.contact || !player.contact.length) {
+    elements.detailContact.innerHTML = '';
+    return;
+  }
+  const items = player.contact.map(item => `
+    <li class="flex flex-col">
+      <span class="text-xs uppercase tracking-[0.35em] text-slate-500">${item.type}</span>
+      <span class="text-sm text-slate-200">${item.value}</span>
+    </li>
+  `).join('');
+  elements.detailContact.innerHTML = items;
+}
+
+function renderHonors(player) {
+  if (!elements.detailHonors) return;
+  if (!player.achievements || !player.achievements.length) {
+    elements.detailHonors.innerHTML = '';
+    return;
+  }
+  const items = player.achievements.map(item => `<li class="rounded-2xl border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">${item}</li>`).join('');
+  elements.detailHonors.innerHTML = items;
+}
+
+function renderFixtures(player) {
+  if (!elements.detailFixtures) return;
+  if (!player.fixtures || !player.fixtures.length) {
+    elements.detailFixtures.innerHTML = '';
+    return;
+  }
+  const items = player.fixtures.map(fixture => `
+    <li class="rounded-2xl border border-slate-600/40 bg-slate-900/70 px-3 py-3">
+      <p class="text-sm text-slate-200">${fixture.opponent}</p>
+      <p class="text-xs uppercase tracking-[0.35em] text-slate-500">${fixture.date} • ${fixture.competition}</p>
+    </li>
+  `).join('');
+  elements.detailFixtures.innerHTML = items;
+}
+
+function highlightActiveCard() {
+  if (!elements.playerList) return;
+  elements.playerList.querySelectorAll('.player-card').forEach(card => {
+    const isActive = card.dataset.playerId === state.currentPlayerId;
+    card.classList.toggle('active', isActive);
+  });
+}
+
+function updateActionButtons(player) {
+  if (!elements.saveProspect || !elements.openMessage) return;
+  const stage = accountStages[state.stageIndex];
+  const saved = player ? state.savedProspects.has(player.id) : false;
+  const limit = stage.savedLimit;
+  const reachedLimit = Number.isFinite(limit) && state.savedProspects.size >= limit;
+
+  if (!player) {
+    elements.saveProspect.disabled = true;
+    elements.saveProspect.textContent = 'Save to notebook';
+    elements.openMessage.disabled = true;
+    elements.openMessage.textContent = 'Compose message';
+    return;
+  }
+
+  if (stage.messagingDisabled && stage.id === 'dormant') {
+    elements.saveProspect.disabled = true;
+    elements.saveProspect.textContent = 'Reactivate to save prospects';
+  } else if (saved) {
+    elements.saveProspect.disabled = true;
+    elements.saveProspect.textContent = 'Saved in notebook';
+  } else if (reachedLimit) {
+    elements.saveProspect.disabled = true;
+    elements.saveProspect.textContent = 'Notebook limit reached';
+  } else {
+    elements.saveProspect.disabled = false;
+    elements.saveProspect.textContent = 'Save to notebook';
+  }
+
+  const requiresSaved = stage.requireSavedForMessaging;
+  const canMessage = !stage.messagingDisabled && (!requiresSaved || saved);
+  elements.openMessage.disabled = !canMessage;
+  elements.openMessage.textContent = stage.messagingDisabled
+    ? 'Messaging paused'
+    : requiresSaved && !saved
+      ? 'Save to message'
+      : 'Compose message';
+}
+
+function handleSaveProspect(playerId) {
+  const player = playerMap.get(playerId);
+  if (!player) return;
+  const stage = accountStages[state.stageIndex];
+  if (stage.messagingDisabled && stage.id === 'dormant') {
+    showToast('Account dormant — reactivate to save prospects.', 'warning');
+    return;
+  }
+  const alreadySaved = state.savedProspects.has(playerId);
+  if (alreadySaved) {
+    showToast('Already saved in your notebook.', 'info');
+    return;
+  }
+  const limit = stage.savedLimit;
+  if (Number.isFinite(limit) && state.savedProspects.size >= limit) {
+    showToast('You reached your notebook limit for this tier.', 'warning');
+    return;
+  }
+
+  state.savedProspects.set(playerId, {
+    playerId,
+    savedAt: new Date(),
+    note: '',
+    stageSnapshot: stage.id
+  });
+  renderSavedProspects();
+  updateMessagingAccess();
+  showToast(`${player.name} added to your notebook.`, 'success');
+}
+
+function removeProspect(playerId) {
+  const player = playerMap.get(playerId);
+  if (!state.savedProspects.has(playerId)) return;
+  state.savedProspects.delete(playerId);
+  renderSavedProspects();
+  updateMessagingAccess();
+  showToast(`${player ? player.name : 'Prospect'} removed from notebook.`, 'info');
+}
+
+function renderSavedProspects() {
+  if (!elements.savedContainer) return;
+  const entries = Array.from(state.savedProspects.values()).sort((a, b) => b.savedAt - a.savedAt);
+  const stage = accountStages[state.stageIndex];
+  const limit = stage.savedLimit;
+  const capacityLabel = limit === Infinity ? 'Unlimited' : `${state.savedProspects.size} / ${limit}`;
+
+  if (elements.accountSavedCount) {
+    elements.accountSavedCount.textContent = String(state.savedProspects.size);
+  }
+  if (elements.accountCapacity) {
+    elements.accountCapacity.textContent = capacityLabel;
+  }
+  if (elements.savedCountBadge) {
+    elements.savedCountBadge.textContent = `${state.savedProspects.size} saved`;
+  }
+
+  if (!entries.length) {
+    elements.savedContainer.innerHTML = '';
+    if (elements.savedEmpty) elements.savedEmpty.classList.remove('hidden');
+    updateActionButtons(playerMap.get(state.currentPlayerId));
+    return;
+  }
+
+  if (elements.savedEmpty) {
+    elements.savedEmpty.classList.add('hidden');
+  }
+
+  const cards = entries.map(entry => {
+    const player = playerMap.get(entry.playerId);
+    if (!player) return '';
+    const savedOn = entry.savedAt ? formatDate.format(entry.savedAt) : '';
+    const keyStat = player.keyStats && player.keyStats.length ? `${player.keyStats[0].label}: ${player.keyStats[0].value}` : '';
+    return `
+      <div class="notebook-card" data-player-id="${player.id}">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <p class="text-xs uppercase tracking-[0.35em] text-emerald-200">${player.position}</p>
+            <p class="mt-1 text-lg font-semibold text-white">${player.name}</p>
+            <p class="text-xs text-slate-400">${player.club}</p>
+          </div>
+          <button type="button" class="btn-outline" data-remove-prospect>Remove</button>
+        </div>
+        <p class="mt-3 text-xs uppercase tracking-[0.35em] text-slate-500">Saved ${savedOn}</p>
+        <p class="mt-2 text-xs text-slate-400">${keyStat}</p>
+        <label class="mt-4 block text-xs uppercase tracking-[0.35em] text-slate-500">Notebook note
+          <textarea data-prospect-note class="mt-2" placeholder="Add tactical fit or next steps">${entry.note || ''}</textarea>
+        </label>
+        <div class="mt-4 flex items-center justify-between text-xs text-slate-400">
+          <span>${player.availability || ''}</span>
+          <button type="button" class="btn-outline" data-open-prospect>Open profile</button>
+        </div>
+      </div>
+    `;
+  }).join('');
+
+  elements.savedContainer.innerHTML = cards;
+  updateActionButtons(playerMap.get(state.currentPlayerId));
+}
+
+function updateMessagingAccess() {
+  const stage = accountStages[state.stageIndex];
+  if (!stage) return;
+  const requiresSaved = stage.requireSavedForMessaging;
+  const savedEntries = Array.from(state.savedProspects.keys());
+  const recipients = stage.messagingDisabled
+    ? []
+    : requiresSaved
+      ? savedEntries.map(id => playerMap.get(id)).filter(Boolean)
+      : players;
+
+  if (elements.messagingAvailability) {
+    const baseMessage = stage.messaging;
+    const needsSave = requiresSaved && !stage.messagingDisabled && !recipients.length;
+    elements.messagingAvailability.textContent = needsSave
+      ? `${baseMessage} Save a player to unlock this panel.`
+      : baseMessage;
+  }
+
+  if (elements.messagePlayer) {
+    const options = recipients.map(player => `<option value="${player.id}">${player.name} — ${player.position}</option>`).join('');
+    elements.messagePlayer.innerHTML = options || '<option value="" disabled>No eligible prospects</option>';
+    const currentSelection = recipients.find(player => player.id === state.currentPlayerId);
+    if (currentSelection) {
+      elements.messagePlayer.value = currentSelection.id;
+    } else if (recipients.length) {
+      elements.messagePlayer.value = recipients[0].id;
+    } else {
+      elements.messagePlayer.value = '';
+    }
+    elements.messagePlayer.disabled = stage.messagingDisabled || !recipients.length;
+  }
+
+  if (elements.messageChannel) {
+    const allowedChannels = stage.messagingDisabled
+      ? []
+      : stage.id === 'basic'
+        ? ['Direct Message', 'Email Intro']
+        : ['Direct Message', 'Email Intro', 'WhatsApp Call'];
+    elements.messageChannel.innerHTML = allowedChannels.map(channel => `<option value="${channel}">${channel}</option>`).join('');
+    elements.messageChannel.disabled = stage.messagingDisabled || !allowedChannels.length;
+  }
+
+  const fields = [elements.messageSubject, elements.messageBody, elements.submitMessage];
+  fields.forEach(field => {
+    if (!field) return;
+    field.disabled = stage.messagingDisabled || (stage.requireSavedForMessaging && !state.savedProspects.size);
+  });
+
+  if (elements.messageForm) {
+    elements.messageForm.classList.toggle('opacity-40', stage.messagingDisabled);
+    elements.messageForm.classList.toggle('pointer-events-none', stage.messagingDisabled);
+  }
+
+  updateActionButtons(playerMap.get(state.currentPlayerId));
+}
+
+function handleMessageSubmit(event) {
+  event.preventDefault();
+  const stage = accountStages[state.stageIndex];
+  if (stage.messagingDisabled) {
+    showToast('Messaging disabled while the account is dormant. Reactivate to reach out.', 'warning');
+    return;
+  }
+
+  const playerId = elements.messagePlayer ? elements.messagePlayer.value : '';
+  const channel = elements.messageChannel ? elements.messageChannel.value : '';
+  const subject = elements.messageSubject ? elements.messageSubject.value.trim() : '';
+  const body = elements.messageBody ? elements.messageBody.value.trim() : '';
+
+  if (!playerId) {
+    showToast('Select a player before sending a message.', 'warning');
+    return;
+  }
+  if (stage.requireSavedForMessaging && !state.savedProspects.has(playerId)) {
+    showToast('Save this prospect before messaging on the Basic tier.', 'warning');
+    return;
+  }
+  if (!subject || !body) {
+    showToast('Add a subject and message body before sending.', 'warning');
+    return;
+  }
+
+  const message = {
+    id: Date.now(),
+    playerId,
+    channel,
+    subject,
+    body,
+    timestamp: new Date()
+  };
+  state.messages.unshift(message);
+  if (state.messages.length > 10) {
+    state.messages.length = 10;
+  }
+  renderMessageHistory();
+
+  if (elements.messageForm) {
+    elements.messageForm.reset();
+  }
+  if (elements.messageFeedback) {
+    elements.messageFeedback.textContent = `Message staged for ${playerMap.get(playerId)?.name || 'prospect'} via ${channel}.`;
+    elements.messageFeedback.classList.remove('hidden');
+    setTimeout(() => {
+      elements.messageFeedback.classList.add('hidden');
+    }, 4000);
+  }
+  updateMessagingAccess();
+  showToast(`Message staged for ${playerMap.get(playerId)?.name || 'prospect'}.`, 'success');
+}
+
+function renderMessageHistory() {
+  if (!elements.messageHistory) return;
+  if (!state.messages.length) {
+    elements.messageHistory.innerHTML = '<li class="text-slate-500">No messages yet. Reach out to a prospect to populate this feed.</li>';
+    return;
+  }
+  const items = state.messages.slice(0, 5).map(entry => {
+    const player = playerMap.get(entry.playerId);
+    const name = player ? player.name : 'Archived prospect';
+    const stamp = formatDateTime.format(entry.timestamp);
+    return `
+      <li class="message-history-item">
+        <strong>${name}</strong> · <span>${entry.channel}</span>
+        <p class="mt-2 text-sm text-slate-300">${entry.subject}</p>
+        <p class="mt-1 text-xs text-slate-400">${entry.body}</p>
+        <time>${stamp}</time>
+      </li>
+    `;
+  }).join('');
+  elements.messageHistory.innerHTML = items;
+}
+
+function handleOpenMessage(playerId) {
+  const stage = accountStages[state.stageIndex];
+  const player = playerMap.get(playerId);
+  if (!player) return;
+  if (stage.messagingDisabled) {
+    showToast('Messaging disabled while the account is dormant.', 'warning');
+    return;
+  }
+  if (stage.requireSavedForMessaging && !state.savedProspects.has(playerId)) {
+    showToast('Save this player to unlock messaging on the Basic tier.', 'warning');
+    return;
+  }
+  if (elements.messagePlayer) {
+    const option = Array.from(elements.messagePlayer.options).find(opt => opt.value === playerId);
+    if (option) {
+      elements.messagePlayer.value = playerId;
+    }
+  }
+  if (elements.messageSubject) {
+    elements.messageSubject.focus();
+  }
+  if (elements.messageForm && elements.messageForm.scrollIntoView) {
+    elements.messageForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+  showToast(`Composing message to ${player.name}.`, 'info');
+}
+
+function showToast(message, tone = 'info') {
+  if (!elements.toastShell || !elements.toastContent) return;
+  elements.toastContent.textContent = message;
+  if (tone === 'info') {
+    delete elements.toastShell.dataset.tone;
+  } else {
+    elements.toastShell.dataset.tone = tone;
+  }
+  elements.toastShell.classList.remove('hidden');
+  elements.toastShell.style.opacity = '1';
+  elements.toastShell.style.transform = 'translate(-50%, 0)';
+  clearTimeout(toastTimeoutId);
+  toastTimeoutId = setTimeout(() => {
+    elements.toastShell.style.opacity = '0';
+    elements.toastShell.style.transform = 'translate(-50%, -12px)';
+    setTimeout(() => {
+      elements.toastShell.classList.add('hidden');
+    }, 320);
+  }, 3400);
+}
+
+function initializeApp() {
+  cacheElements();
+  attachEventListeners();
+  updateRoleUI();
+  updateAccountPanel();
+  renderSavedProspects();
+  renderMessageHistory();
+  applyFilters();
+  updateMessagingAccess();
+}
+
+document.addEventListener('DOMContentLoaded', initializeApp);

--- a/scoutapp/styles.css
+++ b/scoutapp/styles.css
@@ -1,0 +1,702 @@
+:root {
+  color-scheme: dark;
+  --font-base: 'Inter', 'Segoe UI', sans-serif;
+  --font-display: 'Rajdhani', 'Inter', sans-serif;
+  --color-bg: #020617;
+  --color-card: rgba(15, 23, 42, 0.78);
+  --color-border: rgba(148, 163, 184, 0.18);
+  --color-text: #f8fafc;
+  --color-muted: rgba(148, 163, 184, 0.85);
+  --color-accent: #22c55e;
+  --color-accent-soft: rgba(34, 197, 94, 0.08);
+  --color-accent-strong: rgba(34, 197, 94, 0.45);
+  --color-highlight: rgba(56, 189, 248, 0.35);
+  --transition: 200ms ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-base);
+  line-height: 1.6;
+  position: relative;
+}
+
+body::before,
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+body::before {
+  background-image:
+    linear-gradient(90deg, rgba(34, 197, 94, 0.05) 1px, transparent 1px),
+    linear-gradient(0deg, rgba(34, 197, 94, 0.05) 1px, transparent 1px);
+  background-size: 120px 120px;
+  opacity: 0.65;
+}
+
+body::after {
+  background:
+    radial-gradient(circle at 12% 18%, rgba(34, 197, 94, 0.12), transparent 58%),
+    radial-gradient(circle at 80% 12%, rgba(56, 189, 248, 0.14), transparent 55%),
+    radial-gradient(circle at 60% 80%, rgba(14, 165, 233, 0.12), transparent 55%);
+  opacity: 0.9;
+}
+
+#app {
+  position: relative;
+  z-index: 1;
+}
+
+h1,
+h2,
+h3,
+.stat-value {
+  font-family: var(--font-display);
+  letter-spacing: 0.01em;
+}
+
+a {
+  color: inherit;
+}
+
+a,
+button {
+  font-family: inherit;
+}
+
+button {
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+button:focus-visible,
+select:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid rgba(34, 197, 94, 0.7);
+  outline-offset: 3px;
+}
+
+.glass-card {
+  position: relative;
+  border-radius: 2rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-card);
+  backdrop-filter: blur(28px);
+  -webkit-backdrop-filter: blur(28px);
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.45);
+}
+
+.glass-board {
+  border-radius: 2rem;
+  border: 1px solid rgba(34, 197, 94, 0.18);
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.92) 0%, rgba(15, 23, 42, 0.7) 55%, rgba(15, 23, 42, 0.52) 100%);
+  padding: 2rem;
+  box-shadow: 0 32px 70px rgba(34, 197, 94, 0.18);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+}
+
+.glass-subcard {
+  border-radius: 1.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(2, 6, 23, 0.7);
+  padding: 1.75rem;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.55);
+}
+
+.match-card {
+  border-radius: 1.5rem;
+  background: rgba(15, 23, 42, 0.86);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1.4rem;
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.45);
+}
+
+.match-card__label {
+  font-size: 0.65rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.match-card__title {
+  margin-top: 0.4rem;
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  color: #ffffff;
+}
+
+.match-card__meta {
+  margin-top: 0.45rem;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.stat-block {
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.85);
+  padding: 1.4rem;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.45);
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.stat-value {
+  margin-top: 0.2rem;
+  font-size: 1.9rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.stat-sub {
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.role-button,
+.role-switch {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  padding: 0.85rem 1.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.65rem;
+  color: #ecfdf5;
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.35), rgba(34, 197, 94, 0.18));
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition);
+}
+
+.role-button:hover,
+.role-switch:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(34, 197, 94, 0.25);
+}
+
+.role-button--ghost,
+.role-switch--ghost {
+  background: rgba(15, 23, 42, 0.8);
+  color: rgba(226, 232, 240, 0.9);
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+.role-button.is-active,
+.role-switch.is-active {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.9), rgba(16, 185, 129, 0.72));
+  color: #022c22;
+  border-color: rgba(34, 197, 94, 0.92);
+  box-shadow: 0 24px 55px rgba(34, 197, 94, 0.35);
+}
+
+.role-button--ghost.is-active,
+.role-switch--ghost.is-active {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.9), rgba(16, 185, 129, 0.72));
+  color: #022c22;
+  border-color: rgba(34, 197, 94, 0.92);
+}
+
+
+.role-button--ghost:hover,
+.role-switch--ghost:hover {
+  border-color: rgba(34, 197, 94, 0.5);
+  box-shadow: 0 16px 32px rgba(34, 197, 94, 0.18);
+}
+
+.role-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: rgba(34, 197, 94, 0.15);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  padding: 0.55rem 1.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.6rem;
+  color: rgba(209, 250, 229, 0.9);
+}
+
+.btn-primary,
+.btn-outline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.85rem 1.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.65rem;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition), border-color var(--transition);
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.85), rgba(16, 185, 129, 0.75));
+  color: #022c22;
+  border: 1px solid rgba(34, 197, 94, 0.9);
+  box-shadow: 0 18px 45px rgba(34, 197, 94, 0.3);
+}
+
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 55px rgba(34, 197, 94, 0.4);
+}
+
+.btn-outline {
+  background: rgba(15, 23, 42, 0.8);
+  color: rgba(226, 232, 240, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.38);
+}
+
+.btn-outline:hover {
+  border-color: rgba(34, 197, 94, 0.5);
+  color: #d1fae5;
+  box-shadow: 0 15px 36px rgba(34, 197, 94, 0.22);
+}
+
+.mini-panel {
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.85);
+  padding: 1.25rem 1.35rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.4);
+}
+
+.mini-panel__label {
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.55rem;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.mini-panel__value {
+  margin-top: 0.45rem;
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  color: #ffffff;
+}
+
+.mini-panel__hint {
+  margin-top: 0.35rem;
+  font-size: 0.65rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.filter-label {
+  display: block;
+  font-size: 0.6rem;
+  letter-spacing: 0.35em;
+}
+
+.filter-input {
+  width: 100%;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.88);
+  color: #f8fafc;
+  padding: 0.85rem 1rem;
+  font-size: 0.85rem;
+  letter-spacing: normal;
+  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+.filter-input::placeholder {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.filter-input:hover {
+  border-color: rgba(34, 197, 94, 0.35);
+}
+
+.filter-input:focus {
+  border-color: rgba(34, 197, 94, 0.65);
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.25);
+}
+
+.highlight-shell {
+  position: relative;
+  border-radius: 1.75rem;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  background: linear-gradient(150deg, rgba(6, 95, 70, 0.35), rgba(15, 23, 42, 0.9));
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.highlight-shell iframe,
+.highlight-shell video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.section-title {
+  font-size: 0.75rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.detail-stats .stat-card {
+  border-radius: 1.4rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.85);
+  padding: 1.1rem 1.2rem;
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+  position: relative;
+  overflow: hidden;
+}
+
+.detail-stats .stat-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.12), transparent 55%);
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.detail-stats .stat-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(34, 197, 94, 0.45);
+  box-shadow: 0 20px 40px rgba(34, 197, 94, 0.2);
+}
+
+.detail-stats .stat-card:hover::after {
+  opacity: 1;
+}
+
+.detail-stats .stat-label {
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.detail-stats .stat-number {
+  margin-top: 0.35rem;
+  font-family: var(--font-display);
+  font-size: 1.55rem;
+  color: #ffffff;
+}
+
+.detail-stats .stat-context {
+  margin-top: 0.45rem;
+  font-size: 0.7rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+
+#detail-metrics .metric-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.85);
+  padding: 0.85rem 1rem;
+}
+
+#detail-metrics dt {
+  font-size: 0.6rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+#detail-metrics dd {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  color: #f8fafc;
+}
+
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.75rem;
+  background: rgba(34, 197, 94, 0.14);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  color: rgba(209, 250, 229, 0.9);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.player-card {
+  width: 100%;
+  text-align: left;
+  border-radius: 1.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.82);
+  padding: 1.2rem 1.35rem;
+  color: inherit;
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+  position: relative;
+  overflow: hidden;
+}
+
+.player-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, rgba(34, 197, 94, 0.16), transparent 55%);
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.player-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(34, 197, 94, 0.45);
+  box-shadow: 0 22px 48px rgba(34, 197, 94, 0.22);
+}
+
+.player-card:hover::after,
+.player-card.active::after {
+  opacity: 1;
+}
+
+.player-card.active {
+  border-color: rgba(34, 197, 94, 0.65);
+  box-shadow: 0 26px 60px rgba(34, 197, 94, 0.28);
+}
+
+.player-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.player-card__position {
+  font-size: 0.6rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: rgba(16, 185, 129, 0.8);
+}
+
+.player-card__name {
+  margin-top: 0.45rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.player-card__club {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.player-card__stats {
+  margin-top: 1.1rem;
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  font-size: 0.75rem;
+}
+
+.player-card__stat {
+  border-radius: 1.05rem;
+  background: rgba(34, 197, 94, 0.08);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+  padding: 0.7rem 0.75rem;
+  text-align: center;
+}
+
+.player-card__stat span {
+  display: block;
+}
+
+.player-card__stat .label {
+  font-size: 0.55rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.player-card__stat .value {
+  margin-top: 0.25rem;
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  color: #ecfdf5;
+}
+
+.player-card__footer {
+  margin-top: 1.15rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.notebook-card {
+  border-radius: 1.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.85);
+  padding: 1.35rem;
+  position: relative;
+  box-shadow: 0 24px 45px rgba(2, 6, 23, 0.45);
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.notebook-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(34, 197, 94, 0.45);
+  box-shadow: 0 24px 48px rgba(34, 197, 94, 0.22);
+}
+
+.notebook-card textarea {
+  width: 100%;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.88);
+  color: #f8fafc;
+  padding: 0.75rem 0.85rem;
+  font-size: 0.85rem;
+  resize: vertical;
+  min-height: 4.5rem;
+}
+
+.notebook-card textarea::placeholder {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.notebook-card textarea:focus {
+  border-color: rgba(34, 197, 94, 0.55);
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.2);
+}
+
+.message-history-item {
+  border-radius: 1.4rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.8);
+  padding: 1rem 1.2rem;
+  font-size: 0.85rem;
+}
+
+.message-history-item strong {
+  font-family: var(--font-display);
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.message-history-item time {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.toast-shell {
+  position: fixed;
+  top: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 50;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.toast-shell.hidden {
+  display: none;
+}
+
+.toast-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(34, 197, 94, 0.4);
+  background: rgba(2, 6, 23, 0.9);
+  color: rgba(209, 250, 229, 0.92);
+  padding: 0.75rem 1.4rem;
+  font-size: 0.85rem;
+  box-shadow: 0 24px 55px rgba(34, 197, 94, 0.32);
+}
+
+.toast-shell[data-tone="success"] .toast-content {
+  border-color: rgba(34, 197, 94, 0.65);
+  background: rgba(4, 47, 37, 0.9);
+  color: rgba(240, 253, 244, 0.92);
+  box-shadow: 0 24px 55px rgba(34, 197, 94, 0.42);
+}
+
+.toast-shell[data-tone="warning"] .toast-content {
+  border-color: rgba(251, 191, 36, 0.6);
+  background: rgba(55, 30, 0, 0.85);
+  color: rgba(254, 243, 199, 0.92);
+  box-shadow: 0 24px 55px rgba(251, 191, 36, 0.35);
+}
+
+.toast-shell[data-tone="danger"] .toast-content {
+  border-color: rgba(248, 113, 113, 0.6);
+  background: rgba(76, 5, 25, 0.9);
+  color: rgba(254, 226, 226, 0.92);
+  box-shadow: 0 24px 55px rgba(248, 113, 113, 0.35);
+}
+
+@media (max-width: 1024px) {
+  .glass-card,
+  .glass-board {
+    border-radius: 1.5rem;
+  }
+
+  .player-card__stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .role-button,
+  .role-switch,
+  .btn-primary,
+  .btn-outline {
+    letter-spacing: 0.25em;
+    padding: 0.75rem 1.4rem;
+    font-size: 0.6rem;
+  }
+
+  .stat-value {
+    font-size: 1.6rem;
+  }
+
+  .highlight-shell {
+    border-radius: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- restore the productivity dashboard files at the root so the main site keeps the original experience
- add a dedicated `scoutapp/` directory that contains the ScoutLink soccer networking UI, JavaScript, and styles
- update the ScoutLink HTML to reference its local assets so it can be served from `https://www.bananadona.com/scoutapp`

## Testing
- node --check --input-type=module - < public/main.js
- node --check scoutapp/main.js

------
https://chatgpt.com/codex/tasks/task_e_68ce301fae74832fa37daf2166e52cc8